### PR TITLE
feat: implement story functionality with Filament integration and authorization

### DIFF
--- a/app/Enums/Story/Status.php
+++ b/app/Enums/Story/Status.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums\Story;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum Status: string implements HasColor, HasLabel
+{
+    case Draft = 'draft';
+    case Publish = 'publish';
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Draft => 'warning',
+            default => 'success',
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return __('story.resource.status.'.$this->value);
+    }
+}

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -151,7 +151,13 @@ class StoryResource extends Resource implements HasShieldPermissions
                     ->label(__('story.resource.title'))
                     ->limit(30),
                 Tables\Columns\TextColumn::make('status')
-                    ->badge(),
+                    ->badge()
+                    ->formatStateUsing(function (Story $record, $state) {
+                        return match ($record->status) {
+                            Status::Publish => $record->published_at > now() ? __('story.resource.status.pending') : $state,
+                            default => $state,
+                        };
+                    }),
                 static::canViewAll() ? Tables\Columns\TextColumn::make('creator.name')
                     ->label(ucfirst(__('validation.attributes.creator'))) : null,
                 Tables\Columns\TextColumn::make('published_at')

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\StoryResource\Pages;
 use App\Models\Story;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
@@ -10,6 +11,7 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -111,11 +113,13 @@ class StoryResource extends Resource implements HasShieldPermissions
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
+                ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    ReferenceAwareDeleteBulkAction::make(),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\UserResource\Utils\Creator;
 use App\Models\Story;
 use App\Utils\Locale;
 use Awcodes\Curator\Components\Forms\CuratorPicker;
+use Awcodes\Curator\Components\Tables\CuratorColumn;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Filament\Facades\Filament;
 use Filament\Forms;
@@ -15,7 +16,6 @@ use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Resources\Resource;
 use Filament\Tables;
-use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Table;
 use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Builder;
@@ -25,7 +25,7 @@ class StoryResource extends Resource implements HasShieldPermissions
 {
     protected static ?string $model = Story::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
 
     public static function canViewAll(): bool
     {
@@ -136,29 +136,35 @@ class StoryResource extends Resource implements HasShieldPermissions
     public static function table(Table $table): Table
     {
         return $table
-            ->columns([
-                Tables\Columns\TextColumn::make('id')
-                    ->label('ID')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('creator.name')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('cover_media_id')
-                    ->searchable(),
+            ->columns(array_filter([
+                CuratorColumn::make('cover_media_id')
+                    ->label(__('story.resource.cover_media'))
+                    ->size(40),
+                Tables\Columns\TextColumn::make('title')
+                    ->label(__('story.resource.title'))
+                    ->limit(30),
+                static::canViewAll() ? Tables\Columns\TextColumn::make('creator.name')
+                    ->label(ucfirst(__('validation.attributes.creator'))) : null,
                 Tables\Columns\TextColumn::make('published_at')
                     ->dateTime()
+                    ->label(__('story.resource.published_at'))
+                    ->toggleable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.created_at')))
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
                     ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.updated_at')))
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
-            ])
+            ]))
             ->actions([
-                ActionGroup::make([
+                Tables\Actions\ActionGroup::make([
                     Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
                 ]),
             ])
             ->bulkActions([

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\Story\Status;
 use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\StoryResource\Pages;
 use App\Filament\Resources\UserResource\Utils\Creator;
@@ -70,6 +71,12 @@ class StoryResource extends Resource implements HasShieldPermissions
                         'sm' => 4,
                     ]),
                     Forms\Components\Group::make([
+                        Forms\Components\Section::make([
+                            Forms\Components\Radio::make('status')
+                                ->default(Status::Draft)
+                                ->options(Status::class)
+                                ->required(),
+                        ]),
                         Forms\Components\Section::make([
                             Forms\Components\DateTimePicker::make('published_at')
                                 ->default(now()),
@@ -143,6 +150,8 @@ class StoryResource extends Resource implements HasShieldPermissions
                 Tables\Columns\TextColumn::make('title')
                     ->label(__('story.resource.title'))
                     ->limit(30),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
                 static::canViewAll() ? Tables\Columns\TextColumn::make('creator.name')
                     ->label(ucfirst(__('validation.attributes.creator'))) : null,
                 Tables\Columns\TextColumn::make('published_at')

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\StoryResource\Pages;
+use App\Models\Story;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class StoryResource extends Resource
+{
+    protected static ?string $model = Story::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('creator_id')
+                    ->relationship('creator', 'name')
+                    ->required(),
+                Forms\Components\TextInput::make('cover_media_id')
+                    ->maxLength(26)
+                    ->default(null),
+                Forms\Components\Textarea::make('title')
+                    ->required()
+                    ->columnSpanFull(),
+                Forms\Components\Textarea::make('content')
+                    ->required()
+                    ->columnSpanFull(),
+                Forms\Components\DateTimePicker::make('published_at'),
+            ]);
+    }
+
+    public static function getModelLabel(): string
+    {
+        return trans_choice('story.resource.model_label', 1);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListStories::route('/'),
+            'create' => Pages\CreateStory::route('/create'),
+            'edit' => Pages\EditStory::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans_choice('story.resource.model_label', 2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('creator.name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('cover_media_id')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -4,17 +4,25 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\StoryResource\Pages;
 use App\Models\Story;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
+use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
-class StoryResource extends Resource
+class StoryResource extends Resource implements HasShieldPermissions
 {
     protected static ?string $model = Story::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function canViewAll(): bool
+    {
+        return static::can('viewAll');
+    }
 
     public static function form(Form $form): Form
     {
@@ -48,6 +56,30 @@ class StoryResource extends Resource
             'create' => Pages\CreateStory::route('/create'),
             'edit' => Pages\EditStory::route('/{record}/edit'),
         ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            'view_all',
+        ];
+    }
+
+    /**
+     * @return Builder<Story>
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        if (! static::canViewAll()) {
+            $query->where('creator_id', Filament::auth()->id());
+        }
+
+        return $query;
     }
 
     public static function getPluralModelLabel(): string

--- a/app/Filament/Resources/StoryResource/Pages/CreateStory.php
+++ b/app/Filament/Resources/StoryResource/Pages/CreateStory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\StoryResource\Pages;
+
+use App\Filament\Resources\StoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateStory extends CreateRecord
+{
+    protected static string $resource = StoryResource::class;
+}

--- a/app/Filament/Resources/StoryResource/Pages/EditStory.php
+++ b/app/Filament/Resources/StoryResource/Pages/EditStory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\StoryResource\Pages;
+
+use App\Filament\Resources\StoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditStory extends EditRecord
+{
+    protected static string $resource = StoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/StoryResource/Pages/ListStories.php
+++ b/app/Filament/Resources/StoryResource/Pages/ListStories.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\StoryResource\Pages;
+
+use App\Filament\Resources\StoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListStories extends ListRecords
+{
+    protected static string $resource = StoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -87,11 +87,22 @@ class Media extends CuratorMedia
 
     public function isReferenced(): bool
     {
+        if ($this->stories()->exists()) {
+            return true;
+        }
         if ($this->usersWithThisAsProfilePhoto()->exists()) {
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * @return HasMany<Story, $this>
+     */
+    public function stories(): HasMany
+    {
+        return $this->hasMany(Story::class, 'cover_media_id');
     }
 
     /**

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\HasCreatorAttribute;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * @property string $id
+ * @property string $creator_id
+ * @property ?string $cover_media_id
+ * @property string $title
+ * @property string $content
+ * @property ?Carbon $published_at
+ * @property ?Carbon $created_at
+ * @property ?Carbon $updated_at
+ * @property-read User $creator
+ * @property-read ?Media $coverMedia
+ */
+class Story extends Model
+{
+    use HasCreatorAttribute;
+
+    /** @use HasFactory<\Database\Factories\StoryFactory> */
+    use HasFactory;
+
+    use HasTranslations;
+    use HasUlids;
+
+    /**
+     * @var array<int, string>
+     */
+    public $translatable = ['title', 'content'];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'id' => 'string',
+        'published_at' => 'datetime',
+    ];
+
+    /**
+     * @return HasOne<Media, $this>
+     */
+    public function coverMedia(): HasOne
+    {
+        return $this->hasOne(Media::class, 'cover_media_id');
+    }
+}

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -52,4 +52,9 @@ class Story extends Model
     {
         return $this->hasOne(Media::class, 'cover_media_id');
     }
+
+    public function isReferenced(): bool
+    {
+        return false;
+    }
 }

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\HasCreatorAttribute;
+use App\Enums\Story\Status;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -16,6 +17,7 @@ use Spatie\Translatable\HasTranslations;
  * @property ?string $cover_media_id
  * @property string $title
  * @property string $content
+ * @property Status $status
  * @property ?Carbon $published_at
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
@@ -43,6 +45,7 @@ class Story extends Model
     protected $casts = [
         'id' => 'string',
         'published_at' => 'datetime',
+        'status' => Status::class,
     ];
 
     /**

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -6,7 +6,7 @@ use App\Concerns\HasCreatorAttribute;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 use Spatie\Translatable\HasTranslations;
 
@@ -46,11 +46,16 @@ class Story extends Model
     ];
 
     /**
-     * @return HasOne<Media, $this>
+     * @var array<int, string>
      */
-    public function coverMedia(): HasOne
+    protected $guarded = [];
+
+    /**
+     * @return BelongsTo<Media, $this>
+     */
+    public function coverMedia(): BelongsTo
     {
-        return $this->hasOne(Media::class, 'cover_media_id');
+        return $this->belongsTo(Media::class, 'cover_media_id');
     }
 
     public function isReferenced(): bool

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Concerns\HasCreatorAttribute;
 use App\Enums\Story\Status;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -64,5 +65,23 @@ class Story extends Model
     public function isReferenced(): bool
     {
         return false;
+    }
+
+    /**
+     * @param  Builder<Story>  $query
+     */
+    public function scopePending(Builder $query): void
+    {
+        $query->where('status', Status::Publish)
+            ->where('published_at', '>', now());
+    }
+
+    /**
+     * @param  Builder<Story>  $query
+     */
+    public function scopePublished(Builder $query): void
+    {
+        $query->where('status', Status::Publish)
+            ->where('published_at', '<=', now());
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -167,6 +167,9 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         if ($this->pages()->exists()) {
             return true;
         }
+        if ($this->stories()->exists()) {
+            return true;
+        }
 
         return false;
     }
@@ -209,5 +212,13 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
     public function profilePhotoMedia(): BelongsTo
     {
         return $this->belongsTo(Media::class, 'profile_photo_media_id');
+    }
+
+    /**
+     * @return HasMany<Story, $this>
+     */
+    public function stories(): HasMany
+    {
+        return $this->hasMany(Story::class, 'creator_id');
     }
 }

--- a/app/Policies/StoryPolicy.php
+++ b/app/Policies/StoryPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class StoryPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Story $story): bool
+    {
+        if ($user->isNot($story->creator) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view all models.
+     */
+    public function viewAll(User $user): bool
+    {
+        return $user->can('view_all_story');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Story $story): bool
+    {
+        if ($user->isNot($story->creator) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Story $story): bool
+    {
+        if ($story->isReferenced()) {
+            return false;
+        }
+        if ($user->isNot($story->creator) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/conventions/FILAMENT_RESOURCE_CONVENTIONS.md
+++ b/conventions/FILAMENT_RESOURCE_CONVENTIONS.md
@@ -2,6 +2,10 @@
 
 These conventions aim to improve code clarity and static analysis using PHPStan.
 
+## Imports
+
+-   **Top-Level Imports:** Use top-level imports for classes and interfaces.
+
 ## Model Labels and Plural Model Labels
 
 -   Each Filament Resource should override the `getModelLabel()` and `getPluralModelLabel()` methods.
@@ -54,6 +58,8 @@ These conventions aim to improve code clarity and static analysis using PHPStan.
 
     Where `{permissions}` is the permissions associated with the Filament Resource (e.g., `view_all`).
 
-## Imports
+## Table and Bulk Actions
 
--   **Top-Level Imports:** Use top-level imports for classes and interfaces.
+-   **Table Actions Grouping:** All individual actions displayed in the table row (e.g., Edit, View, Delete) must be grouped together within a `Tables\Actions\ActionGroup`.
+-   **Bulk Actions Grouping:** All bulk actions (actions that apply to multiple selected rows) must be grouped together within a `Tables\Actions\BulkActionGroup`.
+-   **Deletion Handling:** When implementing a bulk delete action, always use `ReferenceAwareDeleteBulkAction` instead of the standard `Tables\Actions\DeleteBulkAction`. This ensures proper handling of potential data integrity issues related to foreign key constraints or other data dependencies.

--- a/conventions/FILAMENT_RESOURCE_CONVENTIONS.md
+++ b/conventions/FILAMENT_RESOURCE_CONVENTIONS.md
@@ -1,0 +1,13 @@
+# FILAMENT RESOURCE CONVENTIONS
+
+These conventions aim to improve code clarity and static analysis using PHPStan.
+
+## Model Labels and Plural Model Labels
+
+-   Each Filament Resource should override the `getModelLabel()` and `getPluralModelLabel()` methods.
+-   These methods should retrieve the labels from the corresponding language file with this format `lang/{language-code}/{lowercased-singular-model-name}.php` (e.g., `lang/en/page.php`).
+-   The key in the language file should be `'{lowercased-singular-model-name}.resource.model_label'` (e.g., `'page.resource.model_label'`).
+-   The value should be formatted as `singular|plural` (e.g., `'Page|Pages'`).
+-   If the language does not support pluralization, repeat the value (e.g., `'Halaman|Halaman'`).
+-   Use `trans_choice('page.resource.model_label', 1)` for the singular form.
+-   Use `trans_choice('page.resource.model_label', 2)` for the plural form.

--- a/conventions/FILAMENT_RESOURCE_CONVENTIONS.md
+++ b/conventions/FILAMENT_RESOURCE_CONVENTIONS.md
@@ -11,3 +11,49 @@ These conventions aim to improve code clarity and static analysis using PHPStan.
 -   If the language does not support pluralization, repeat the value (e.g., `'Halaman|Halaman'`).
 -   Use `trans_choice('page.resource.model_label', 1)` for the singular form.
 -   Use `trans_choice('page.resource.model_label', 2)` for the plural form.
+
+## Permission and Policy
+
+-   If the model associated with a Filament Resource has a `creator_id` column, the Resource should define a `canViewAll` static method.
+-   If the model associated with a Filament Resource has a `creator_id` column, the Resource must use the following `getEloquentQuery` method:
+
+        ```php
+        use Illuminate\Database\Eloquent\Builder;
+
+        /**
+         * @return Builder<{Model}>
+         */
+        public static function getEloquentQuery(): Builder
+        {
+            $query = parent::getEloquentQuery();
+
+            if (! static::canViewAll()) {
+                $query->where('creator_id', Filament::auth()->id());
+            }
+
+            return $query;
+        }
+        ```
+        Where `{Model}` is the model type associated with the Filament Resource (e.g., `Page`).
+
+-   The implementation of `canViewAll` should simply call the `can` method with the `viewAll` ability: `return static::can('viewAll');`.
+-   If the model _does not_ have a `creator_id` column, the `canViewAll` method _should not_ be defined.
+-   Every Filament Resource should implement the `HasShieldPermissions` interface from `\BezhanSalleh\FilamentShield\Contracts` then implement the `getPermissionPrefixes` method like this:
+
+    ```php
+    /**
+     * @return string[]
+     */
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            {permissions}
+        ];
+    }
+    ```
+
+    Where `{permissions}` is the permissions associated with the Filament Resource (e.g., `view_all`).
+
+## Imports
+
+-   **Top-Level Imports:** Use top-level imports for classes and interfaces.

--- a/conventions/MODEL_CONVENTIONS.md
+++ b/conventions/MODEL_CONVENTIONS.md
@@ -1,0 +1,71 @@
+# MODEL CONVENTIONS
+
+These conventions aim to improve code clarity and static analysis using PHPStan.
+
+## Ulids
+
+All models should use the `HasUlids` trait. The `ulid` column is a string and should not be nullable. For example:
+
+```php
+use App\Concerns\HasUlids;
+class Page extends Model {
+    use HasUlids;
+```
+
+## Docblock Annotations
+
+-   **Model Properties:** Use `@property` to define the model's database columns. Include the data type and nullability (if applicable). Place these annotations above the class definition.
+-   **Nullability:** Ensure that the nullability of properties is correctly reflected in the docblocks.
+-   **Relationships:** Use `@property-read` for relationships. Specify the related model class. For example:
+
+```php
+/**
+ * @property string $title
+ * @property ?string $description
+ */
+```
+
+## Factories
+
+-   **Factory Usage:** Use the `HasFactory` trait.
+-   **Factory Docblock:** Add a `/** @use HasFactory<\Database\Factories\{ModelName}Factory> */` docblock _before_ the `use HasFactory;` statement. This helps PHPStan understand the factory relationship.
+
+    ```php
+    /** @use HasFactory<\Database\Factories\PageFactory> */
+    use HasFactory;
+    ```
+
+    Replace `PageFactory` with the actual name of your model's factory.
+
+## Translatable Attributes
+
+-   **`$translatable` Property:** When a model supports translation, the `$translatable` property must be declared as a public array, annotated with a `@var array<int, string>` docblock.
+
+    ```php
+    /** @var array<int, string> */
+    public $translatable = ['title', 'description'];
+    ```
+
+## Relationship Return Types
+
+-   **Explicit Return Types:** Use explicit return types for relationship methods (e.g., `BelongsTo`, `HasOne`).
+-   **Relationship Docblocks:** Add a `@return` docblock to relationship methods, specifying the related model and the current model. Also, add a return type hint to the function signature itself.
+
+    ```php
+    /**
+     * @return BelongsTo<{RelatedModel}, $this>
+     */
+    public function relatedModel(): BelongsTo
+    {
+        return $this->belongsTo({RelatedModel}::class);
+    }
+
+    ```
+
+    Replace `{RelatedModel}`with the related model class (e.g., `Page::class`) and `relatedModel` with the camelCase name of the related model (e.g., `page`). The first type parameter is the related model and the second is the current model.
+
+-   **Attributes:** Prioritize `App\Concerns\Has{RelatedModel}Attribute` trait when you need to define custom accessors or mutators for relationship attributes. Replace {RelatedModel} with the singular, PascalCase name of the related model.
+
+## Imports
+
+-   **Top-Level Imports:** Use top-level imports for classes.

--- a/conventions/MODEL_CONVENTIONS.md
+++ b/conventions/MODEL_CONVENTIONS.md
@@ -46,6 +46,15 @@ class Page extends Model {
     public $translatable = ['title', 'description'];
     ```
 
+## Mass Assignment
+
+-   **`$guarded` Property:** To allow mass assignment, the `$guarded` property should be defined as a protected array. If you want to allow all fields to be mass-assigned, set it to an empty array.
+
+    ```php
+    /** @var array<int, string> */
+    protected $guarded = [];
+    ```
+
 ## Relationship Return Types
 
 -   **Explicit Return Types:** Use explicit return types for relationship methods (e.g., `BelongsTo`, `HasOne`).

--- a/database/factories/StoryFactory.php
+++ b/database/factories/StoryFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Media;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Story>
+ */
+class StoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'creator_id' => User::factory(),
+            'cover_media_id' => Media::factory(),
+            'title' => [
+                'en' => fake()->sentence(),
+                'fr' => fake()->sentence(),
+            ],
+            'content' => [
+                'en' => fake()->paragraph(),
+                'fr' => fake()->paragraph(),
+            ],
+            'published_at' => fake()->dateTime(),
+        ];
+    }
+}

--- a/database/factories/StoryFactory.php
+++ b/database/factories/StoryFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\Story\Status;
 use App\Models\Media;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -29,7 +30,8 @@ class StoryFactory extends Factory
                 'en' => fake()->paragraph(),
                 'fr' => fake()->paragraph(),
             ],
-            'published_at' => fake()->dateTime(),
+            'status' => Status::Draft,
+            'published_at' => $this->faker->dateTimeThisMonth,
         ];
     }
 }

--- a/database/migrations/2025_04_10_034451_create_stories_table.php
+++ b/database/migrations/2025_04_10_034451_create_stories_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
                 ->constrained('media');
             $table->json('title');
             $table->json('content');
+            $table->string('status');
             $table->dateTime('published_at')->nullable()->index();
             $table->timestamps();
         });

--- a/database/migrations/2025_04_10_034451_create_stories_table.php
+++ b/database/migrations/2025_04_10_034451_create_stories_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stories', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('creator_id')
+                ->constrained('users');
+            $table->foreignUlid('cover_media_id')
+                ->nullable()
+                ->constrained('media');
+            $table->json('title');
+            $table->json('content');
+            $table->dateTime('published_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stories');
+    }
+};

--- a/lang/en/story.php
+++ b/lang/en/story.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'resource' => [
+        'model_label' => 'Story|Stories',
+    ],
+];

--- a/lang/en/story.php
+++ b/lang/en/story.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 return [
     'resource' => [
+        'content' => 'Content',
+        'cover_media' => 'Cover Media',
         'model_label' => 'Story|Stories',
+        'select_cover_media' => 'Select Cover Media',
+        'title' => 'Title',
     ],
 ];

--- a/lang/en/story.php
+++ b/lang/en/story.php
@@ -11,6 +11,7 @@ return [
         'select_cover_media' => 'Select Cover Media',
         'status' => [
             'draft' => 'Draft',
+            'pending' => 'Pending',
             'publish' => 'Publish',
         ],
         'title' => 'Title',

--- a/lang/en/story.php
+++ b/lang/en/story.php
@@ -9,6 +9,10 @@ return [
         'model_label' => 'Story|Stories',
         'published_at' => 'Published at',
         'select_cover_media' => 'Select Cover Media',
+        'status' => [
+            'draft' => 'Draft',
+            'publish' => 'Publish',
+        ],
         'title' => 'Title',
     ],
 ];

--- a/lang/en/story.php
+++ b/lang/en/story.php
@@ -7,6 +7,7 @@ return [
         'content' => 'Content',
         'cover_media' => 'Cover Media',
         'model_label' => 'Story|Stories',
+        'published_at' => 'Published at',
         'select_cover_media' => 'Select Cover Media',
         'title' => 'Title',
     ],

--- a/lang/id/story.php
+++ b/lang/id/story.php
@@ -9,6 +9,10 @@ return [
         'model_label' => 'Cerita|Cerita',
         'published_at' => 'Tanggal Terbit',
         'select_cover_media' => 'Pilih Media Sampul',
+        'status' => [
+            'draft' => 'Konsep',
+            'publish' => 'Terbit',
+        ],
         'title' => 'Judul',
     ],
 ];

--- a/lang/id/story.php
+++ b/lang/id/story.php
@@ -7,6 +7,7 @@ return [
         'content' => 'Konten',
         'cover_media' => 'Media Sampul',
         'model_label' => 'Cerita|Cerita',
+        'published_at' => 'Tanggal Terbit',
         'select_cover_media' => 'Pilih Media Sampul',
         'title' => 'Judul',
     ],

--- a/lang/id/story.php
+++ b/lang/id/story.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'resource' => [
+        'model_label' => 'Cerita|Cerita',
+    ],
+];

--- a/lang/id/story.php
+++ b/lang/id/story.php
@@ -11,6 +11,7 @@ return [
         'select_cover_media' => 'Pilih Media Sampul',
         'status' => [
             'draft' => 'Konsep',
+            'pending' => 'Tunda',
             'publish' => 'Terbit',
         ],
         'title' => 'Judul',

--- a/lang/id/story.php
+++ b/lang/id/story.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 return [
     'resource' => [
+        'content' => 'Konten',
+        'cover_media' => 'Media Sampul',
         'model_label' => 'Cerita|Cerita',
+        'select_cover_media' => 'Pilih Media Sampul',
+        'title' => 'Judul',
     ],
 ];

--- a/tests/Feature/Filament/Resources/StoryResourceTest.php
+++ b/tests/Feature/Filament/Resources/StoryResourceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Enums\Story\Status;
+use App\Filament\Resources\StoryResource;
+use App\Models\Permission;
+use App\Models\Story;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoryResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+    }
+
+    public function test_displays_pending_status_badge_when_story_is_published_in_the_future(): void
+    {
+        $futureDate = now()->addDay();
+
+        Story::factory()->create([
+            'title' => ['en' => 'Future Story'],
+            'status' => Status::Publish,
+            'published_at' => $futureDate,
+            'creator_id' => $this->user->id,
+        ]);
+
+        $this->get(StoryResource::getUrl('index'))
+            ->assertOk()
+            ->assertSee(__('story.resource.status.pending'));
+    }
+
+    public function test_displays_the_actual_status_badge_when_story_is_not_published(): void
+    {
+        $story = Story::factory()->create([
+            'title' => ['en' => 'Draft Story'],
+            'status' => Status::Draft,
+            'creator_id' => $this->user->id,
+        ]);
+
+        $this->get(StoryResource::getUrl('index'))
+            ->assertOk()
+            ->assertSee(ucfirst($story->status->value));
+    }
+
+    public function test_displays_the_actual_status_badge_when_story_is_published_in_the_past(): void
+    {
+        $pastDate = now()->subDay();
+
+        $story = Story::factory()->create([
+            'title' => ['en' => 'Published Story'],
+            'status' => Status::Publish,
+            'published_at' => $pastDate,
+            'creator_id' => $this->user->id,
+        ]);
+
+        $this->get(StoryResource::getUrl('index'))
+            ->assertOk()
+            ->assertSee($story->status->value);
+    }
+
+    public function test_only_shows_stories_created_by_the_current_user_if_they_cannot_view_all(): void
+    {
+        $story = Story::factory()->create([
+            'title' => ['en' => 'My Story'],
+            'creator_id' => $this->user->id,
+        ]);
+
+        $otherStory = Story::factory()->create([
+            'title' => ['en' => 'Other Story'],
+            'creator_id' => User::factory()->create()->id,
+        ]);
+
+        $this->get(StoryResource::getUrl('index'))
+            ->assertOk()
+            ->assertSee($story->title)
+            ->assertDontSee($otherStory->title);
+    }
+
+    public function test_shows_all_stories_if_the_user_can_view_all(): void
+    {
+        Permission::firstOrCreate(['name' => 'view_all_story']);
+        $this->user->givePermissionTo('view_all_story');
+
+        $story = Story::factory()->create([
+            'title' => ['en' => 'My Story'],
+            'creator_id' => $this->user->id,
+        ]);
+
+        $otherStory = Story::factory()->create([
+            'title' => ['en' => 'Other Story'],
+            'creator_id' => User::factory()->create()->id,
+        ]);
+
+        $this->get(StoryResource::getUrl('index'))
+            ->assertOk()
+            ->assertSee($story->title)
+            ->assertSee($otherStory->title);
+    }
+}

--- a/tests/Feature/Models/StoryTest.php
+++ b/tests/Feature/Models/StoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\Story\Status;
+use App\Models\Story;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<string, Story>
+     */
+    private function createStories(): array
+    {
+        return [
+            'publishedStoryPast' => Story::factory()->create([
+                'status' => Status::Publish,
+                'published_at' => Carbon::now()->subDay(),
+            ]),
+            'pendingStory' => Story::factory()->create([
+                'status' => Status::Publish,
+                'published_at' => Carbon::now()->addDay(),
+            ]),
+            'draftStory' => Story::factory()->create([
+                'status' => Status::Draft,
+                'published_at' => Carbon::now()->subDay(),
+            ]),
+        ];
+    }
+
+    public function test_only_returns_published_stories(): void
+    {
+        $stories = $this->createStories();
+        $publishedStories = Story::published()->get();
+
+        $this->assertCount(1, $publishedStories);
+        $this->assertTrue($publishedStories->contains($stories['publishedStoryPast']));
+        $this->assertFalse($publishedStories->contains($stories['pendingStory']));
+        $this->assertFalse($publishedStories->contains($stories['draftStory']));
+    }
+
+    public function test_only_returns_pending_stories(): void
+    {
+        $stories = $this->createStories();
+        $pendingStories = Story::pending()->get();
+
+        $this->assertCount(1, $pendingStories);
+        $this->assertTrue($pendingStories->contains($stories['pendingStory']));
+        $this->assertFalse($pendingStories->contains($stories['publishedStoryPast']));
+        $this->assertFalse($pendingStories->contains($stories['draftStory']));
+    }
+}


### PR DESCRIPTION
This pull request introduces the story functionality, including the model, database migration, factory, and Filament resource, complete with authorization policies.

The changes encompass:

- Creation of the `Story` model with ULIDs, translatable attributes, and relationships with `Media` and `User`.
- Implementation of `StoryResource` within the Filament admin panel, including form, table, and related pages.
- Introduction of authorization policies for `StoryResource`, restricting access based on ownership and permissions.
- Implementation of action grouping and reference-aware deletion in the StoryResource for improved usability and data integrity.
- Enhancement of the `StoryResource` form with translatable fields, Curator Picker for cover media, and the Creator component.
- Enhancement of the `StoryResource` table with CuratorColumn, localized labels, published_at column, conditional display of creator name, and delete action.
- Addition of a `Status` enum to the `Story` model, including draft and publish options, and corresponding UI elements in Filament.
- Addition of `published` and `pending` scopes to the `Story` model to filter stories based on their publication status.
- Display of a `Pending` status badge for stories scheduled for future publication.