### PR TITLE
feat: implement story view count and display with formatting and session protection

### DIFF
--- a/app/Livewire/Story/Concerns/HasStoryTable.php
+++ b/app/Livewire/Story/Concerns/HasStoryTable.php
@@ -22,7 +22,6 @@ trait HasStoryTable
                     'default' => 1,
                     'md' => 2,
                     'lg' => 3,
-                    'xl' => 4,
                 ];
             })
             ->columns([

--- a/app/Livewire/Story/ViewStory.php
+++ b/app/Livewire/Story/ViewStory.php
@@ -49,6 +49,7 @@ class ViewStory extends Component implements HasActions, HasForms
         }
 
         $this->story = $story;
+        $this->story->incrementViewCount();
     }
 
     /**

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -67,6 +67,55 @@ class Story extends Model
     }
 
     /**
+     * Get the view count formatted with suffixes (K, M, B, T).
+     */
+    public function formattedViewCount(): string
+    {
+        $count = $this->view_count;
+
+        if ($count < 1000) {
+            return (string) $count;
+        }
+
+        $suffixes = ['', 'K', 'M', 'B', 'T'];
+        $thresholds = [1, 1000, 1000000, 1000000000, 1000000000000];
+
+        // Find the appropriate suffix and threshold
+        $i = count($thresholds) - 1;
+        while ($i > 0 && $count < $thresholds[$i]) {
+            $i--;
+        }
+
+        // Calculate the raw value scaled by the threshold
+        $rawValue = $count / $thresholds[$i];
+
+        // Calculate the value rounded to 1 decimal place to check for the edge case
+        $roundedToOneDecimal = round($rawValue, 1);
+
+        $finalValue = $rawValue;
+        $finalPrecision = ($rawValue == floor($rawValue)) ? 0 : 1; // Default precision
+
+        // Check if rounding to 1 decimal place results in 1000 or more (the next magnitude base)
+        // This happens for values like 999999, 999999999, etc., when divided by their threshold (1000, 1000000, etc.)
+        // Also ensure we are not already at the highest suffix ('T')
+        if ($roundedToOneDecimal >= 1000 && $i < count($suffixes) - 1) {
+            // This is the edge case where we want 999.9 followed by the current suffix
+            // Calculate 999.9 by flooring after multiplying by 10 and then dividing by 10.
+            $finalValue = floor($rawValue * 10) / 10;
+            $finalPrecision = 1; // Always 1 decimal place for this specific edge case format
+        }
+
+        // Return the rounded value with the determined precision and the suffix
+        // Use number_format to ensure the correct number of decimal places are shown,
+        // especially for the edge case (e.g. 999.9).
+        // number_format handles rounding correctly based on the specified precision.
+        // We use '.' for decimal point and '' for thousands separator.
+        $formattedNumber = number_format($finalValue, $finalPrecision, '.', '');
+
+        return $formattedNumber . $suffixes[$i];
+    }
+
+    /**
      * Increment the view count, protected by session to prevent abuse.
      */
     public function incrementViewCount(): void

--- a/database/migrations/2025_04_22_061912_add_view_count_to_stories_table.php
+++ b/database/migrations/2025_04_22_061912_add_view_count_to_stories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            $table->unsignedBigInteger('view_count')
+                ->default(0)
+                ->after('published_at')
+                ->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            $table->dropIndex(['view_count']);
+            $table->dropColumn('view_count');
+        });
+    }
+};

--- a/resources/views/components/story/meta.blade.php
+++ b/resources/views/components/story/meta.blade.php
@@ -1,8 +1,6 @@
-@props(['icon'])
+@props(['icon', 'iconClass' => 'size-3'])
 
 <div {{ $attributes->merge(['class' => 'flex flex-row items-center gap-1 text-gray-600 dark:text-gray-500']) }}>
-    <x-filament::icon class="size-3" :icon="$icon" />
-    <p class="text-sm">
-        {{ $slot }}
-    </p>
+    <x-filament::icon class="{{ $iconClass }}" :icon="$icon" />
+    {{ $slot }}
 </div>

--- a/resources/views/components/story/table/index.blade.php
+++ b/resources/views/components/story/table/index.blade.php
@@ -40,17 +40,15 @@
 
             {{-- Creator --}}
             <x-story.meta icon="heroicon-m-user" title="{{ $story->creator->name }}">
-                {{ $story->creator->name }}
+                <p class="text-sm">{{ $story->creator->name }}</p>
             </x-story.meta>
 
             <span class="flex-grow"></span>
 
-            {{-- Published Date --}}
-            @if ($story->published_at)
-                <x-story.meta title="{{ $story->published_at->format('Y-m-d H:i') }}" icon="heroicon-m-calendar-days">
-                    {{ $story->published_at->format('Y-m-d H:i') }}
-                </x-story.meta>
-            @endif
+            {{-- View Count --}}
+            <x-story.meta icon="heroicon-m-eye" iconClass="size-2">
+                <p class="text-xs">{{ $story->view_count }}</p>
+            </x-story.meta>
         </div>
     </div>
 </div>

--- a/resources/views/components/story/table/index.blade.php
+++ b/resources/views/components/story/table/index.blade.php
@@ -47,7 +47,7 @@
 
             {{-- View Count --}}
             <x-story.meta icon="heroicon-m-eye" iconClass="size-2">
-                <p class="text-xs">{{ $story->view_count }}</p>
+                <p class="text-xs">{{ $story->formattedViewCount() }}</p>
             </x-story.meta>
         </div>
     </div>

--- a/resources/views/livewire/story/view-story.blade.php
+++ b/resources/views/livewire/story/view-story.blade.php
@@ -1,6 +1,12 @@
 <div>
     <x-header :breadcrumbs="$this->getBreadcrumbs()" :actions="$this->getActions()">
-        {{ $story->title }}
+        <div class="flex flex-col gap-y-2">
+            {{ $story->title }}
+
+            <x-story.meta icon="heroicon-m-eye" iconClass="size-3">
+                <p class="text-sm">{{ $story->formattedViewCount() }}</p>
+            </x-story.meta>
+        </div>
     </x-header>
 
     <x-container>

--- a/tests/Feature/Models/StoryTest.php
+++ b/tests/Feature/Models/StoryTest.php
@@ -34,6 +34,47 @@ class StoryTest extends TestCase
         ];
     }
 
+    /**
+     * Data provider for test_formatted_view_count_formats_correctly.
+     *
+     * @return array<string, array<int|string>>
+     */
+    public static function viewCountFormattingProvider(): array
+    {
+        return [
+            'less than 1000' => [999, '999'],
+            'exactly 1000' => [1000, '1K'],
+            'thousands with decimal' => [1300, '1.3K'],
+            'thousands with whole number' => [2500, '2.5K'],
+            'thousands just under 1000K' => [999000, '999K'],
+            'just under 1 million' => [999999, '999.9K'],
+            'exactly 1 million' => [1000000, '1M'],
+            'millions with decimal' => [1500000, '1.5M'],
+            'millions with whole number' => [5000000, '5M'],
+            'millions just under 1000M' => [999000000, '999M'],
+            'just under 1 billion' => [999999999, '999.9M'],
+            'exactly 1 billion' => [1000000000, '1B'],
+            'billions with decimal' => [1200000000, '1.2B'],
+            'billions just under 1000B' => [999000000000, '999B'],
+            'just under 1 trillion' => [999999999999, '999.9B'],
+            'exactly 1 trillion' => [1000000000000, '1T'],
+            'trillions with decimal' => [2500000000000, '2.5T'],
+            'zero' => [0, '0'],
+        ];
+    }
+
+    /**
+     * Test that formattedViewCount formats the view count correctly with suffixes.
+     *
+     * @dataProvider viewCountFormattingProvider
+     */
+    public function test_formatted_view_count_formats_correctly(int $viewCount, string $expectedFormat): void
+    {
+        $story = Story::factory()->create(['view_count' => $viewCount]);
+
+        $this->assertEquals($expectedFormat, $story->formattedViewCount());
+    }
+
     public function test_increment_view_count_protected_by_session_and_time(): void
     {
         // Use Carbon to control time during the test

--- a/tests/Feature/Models/StoryTest.php
+++ b/tests/Feature/Models/StoryTest.php
@@ -6,6 +6,7 @@ use App\Enums\Story\Status;
 use App\Models\Story;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Session;
 use Tests\TestCase;
 
 class StoryTest extends TestCase
@@ -31,6 +32,60 @@ class StoryTest extends TestCase
                 'published_at' => Carbon::now()->subDay(),
             ]),
         ];
+    }
+
+    public function test_increment_view_count_protected_by_session_and_time(): void
+    {
+        // Use Carbon to control time during the test
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
+        $story = Story::factory()->create(['view_count' => 0]);
+
+        // 1. First call: Should increment
+        $story->incrementViewCount();
+        /** @var array<string, int> */
+        $viewedStories = Session::get('viewed_stories');
+        $this->assertEquals(1, $story->fresh()?->view_count, 'First call should increment');
+        $this->assertArrayHasKey($story->id, $viewedStories, 'Session should record first view');
+        $this->assertEquals($now->timestamp, $viewedStories[$story->id], 'Session timestamp should be recorded');
+
+        // 2. Second call immediately: Should NOT increment (session protection)
+        $story->incrementViewCount();
+        /** @var array<string, int> */
+        $viewedStories = Session::get('viewed_stories');
+        $this->assertEquals(1, $story->fresh()?->view_count, 'Second call immediately should not increment');
+        $this->assertEquals($now->timestamp, $viewedStories[$story->id], 'Session timestamp should not change on immediate second call');
+
+        // 3. Advance time by less than 60 seconds (e.g., 30 seconds)
+        Carbon::setTestNow($now->copy()->addSeconds(30));
+        $story = $story->fresh(); // Reload the model to ensure state is fresh if needed, though increment updates it
+
+        $story?->incrementViewCount();
+        /** @var array<string, int> */
+        $viewedStories = Session::get('viewed_stories');
+        $this->assertEquals(1, $story?->fresh()?->view_count, 'Call after < 60s should not increment');
+        $this->assertEquals($now->timestamp, $viewedStories[$story?->id], 'Session timestamp should not change after < 60s');
+
+        // 4. Advance time by more than 60 seconds (e.g., 61 seconds from the *original* $now)
+        Carbon::setTestNow($now->copy()->addSeconds(61));
+        $story = $story?->fresh(); // Reload
+
+        $story?->incrementViewCount();
+        /** @var array<string, int> */
+        $viewedStories = Session::get('viewed_stories');
+        $this->assertEquals(2, $story?->fresh()?->view_count, 'Call after > 60s should increment');
+        $this->assertEquals(Carbon::now()->timestamp, $viewedStories[$story?->id], 'Session timestamp should be updated after > 60s');
+
+        // 5. Fifth call immediately after the time elapsed increment: Should NOT increment (session protection resets)
+        $story?->incrementViewCount();
+        /** @var array<string, int> */
+        $viewedStories = Session::get('viewed_stories');
+        $this->assertEquals(2, $story?->fresh()?->view_count, 'Fifth call immediately should not increment');
+        $this->assertEquals(Carbon::now()->timestamp, $viewedStories[$story?->id], 'Session timestamp should not change on immediate fifth call');
+
+        // Clean up Carbon test time
+        Carbon::setTestNow(null);
     }
 
     public function test_only_returns_published_stories(): void


### PR DESCRIPTION
This pull request implements story view count functionality with session protection to prevent abuse, formats the view count for readability, and displays it on both the story index table and the story view page.

The following changes were made:

- Added a `view_count` column to the `stories` table and a corresponding property to the `Story` model.
- Implemented the `incrementViewCount()` method in the `Story` model, using session to track viewed stories and incrementing the count only after a certain time has passed or if not viewed in the current session.
- Implemented `formattedViewCount` method to format the view count with suffixes (K, M, B, T) for better readability, including handling edge cases for rounding.
- Updated the story table index page and the story view page to display the formatted view count using the `<x-story.meta>` component.
- Added unit tests to verify the functionality of the `incrementViewCount()` and `formattedViewCount` methods.