### PR TITLE
fix: use laravel gate facade for authorization after authorizer deletion

### DIFF
--- a/resources/views/vendor/curator/components/tables/grid-column.blade.php
+++ b/resources/views/vendor/curator/components/tables/grid-column.blade.php
@@ -1,6 +1,6 @@
 @php
     $record = $getRecord();
-    $canViewAll = \App\Utils\Authorizer::check('viewAll', \App\Models\Media::class);
+    $canViewAll = \Illuminate\Support\Facades\Gate::check('viewAll', \App\Models\Media::class);
 @endphp
 
 <div


### PR DESCRIPTION
This pull request replaces the usage of the deleted `Authorizer` utility class in `grid-column.blade.php` with the standard Laravel Gate facade.

The previous code relied on the `Authorizer` class, which has been removed. This change fixes the broken authorization check by implementing it using the standard Laravel Gate, ensuring the application functions correctly and maintains consistency with other authorization logic.