### PR TITLE
feat: add genre management feature

### DIFF
--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -2,15 +2,21 @@
 
 namespace App\Filament\Resources;
 
+use App\Concerns\HasLocales;
 use App\Filament\Resources\GenreResource\Pages;
 use App\Models\Genre;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use FilamentTiptapEditor\TiptapEditor;
+use SolutionForest\FilamentTranslateField\Forms\Component\Translate;
 
 class GenreResource extends Resource
 {
+    use HasLocales;
+
     protected static ?string $model = Genre::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
@@ -19,7 +25,17 @@ class GenreResource extends Resource
     {
         return $form
             ->schema([
-                //
+                Translate::make()
+                    ->schema([
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255),
+                        TiptapEditor::make('description')
+                            ->label(__('genre.resource.description')),
+                    ])
+                    ->columnSpanFull()
+                    ->locales(static::getSortedLocales())
+                    ->suffixLocaleLabel(),
             ]);
     }
 

--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -30,22 +30,28 @@ class GenreResource extends Resource implements HasShieldPermissions
         return $form
             ->schema([
                 Translate::make()
-                    ->schema(fn (string $locale): array => [
-                        TextInput::make('name')
-                            ->label(__('genre.resource.name'))
-                            ->required()
-                            ->maxLength(255)
-                            ->rules(function (Get $get) use ($locale) {
-                                /** @var string */
-                                $id = $get('id');
+                    ->schema(function (Get $get, string $locale): array {
+                        /** @var array<?string> */
+                        $names = $get('name');
+                        $required = collect($names)->every(fn ($item) => $item === null || trim($item) === '');
 
-                                return [
-                                    new UniqueJsonTranslation(table: 'genres', column: 'name', locale: $locale, ignoreId: $id),
-                                ];
-                            }),
-                        TiptapEditor::make('description')
-                            ->label(__('genre.resource.description')),
-                    ])
+                        return [
+                            TextInput::make('name')
+                                ->label(__('genre.resource.name'))
+                                ->required($required)
+                                ->maxLength(255)
+                                ->rules(function (Get $get) use ($locale) {
+                                    /** @var string */
+                                    $id = $get('id');
+
+                                    return [
+                                        new UniqueJsonTranslation(table: 'genres', column: 'name', locale: $locale, ignoreId: $id),
+                                    ];
+                                }),
+                            TiptapEditor::make('description')
+                                ->label(__('genre.resource.description')),
+                        ];
+                    })
                     ->columnSpanFull()
                     ->locales(static::getSortedLocales())
                     ->suffixLocaleLabel(),

--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -21,7 +21,7 @@ class GenreResource extends Resource implements HasShieldPermissions
 
     protected static ?string $model = Genre::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-bookmark';
 
     public static function form(Form $form): Form
     {
@@ -30,6 +30,7 @@ class GenreResource extends Resource implements HasShieldPermissions
                 Translate::make()
                     ->schema([
                         TextInput::make('name')
+                            ->label(__('genre.resource.name'))
                             ->required()
                             ->maxLength(255),
                         TiptapEditor::make('description')
@@ -39,6 +40,44 @@ class GenreResource extends Resource implements HasShieldPermissions
                     ->locales(static::getSortedLocales())
                     ->suffixLocaleLabel(),
             ]);
+    }
+
+    public static function getModelLabel(): string
+    {
+        return trans_choice('genre.resource.model_label', 1);
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('Administration');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGenres::route('/'),
+            'create' => Pages\CreateGenre::route('/create'),
+            'edit' => Pages\EditGenre::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            'view',
+            'view_any',
+            'create',
+            'update',
+            'delete',
+        ];
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans_choice('genre.resource.model_label', 2);
     }
 
     public static function table(Table $table): Table
@@ -64,9 +103,6 @@ class GenreResource extends Resource implements HasShieldPermissions
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
-            ->filters([
-                //
-            ])
             ->actions([
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\EditAction::make(),
@@ -78,35 +114,5 @@ class GenreResource extends Resource implements HasShieldPermissions
                     ReferenceAwareDeleteBulkAction::make(),
                 ]),
             ]);
-    }
-
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
-    public static function getPages(): array
-    {
-        return [
-            'index' => Pages\ListGenres::route('/'),
-            'create' => Pages\CreateGenre::route('/create'),
-            'edit' => Pages\EditGenre::route('/{record}/edit'),
-        ];
-    }
-
-    /**
-     * @return string[]
-     */
-    public static function getPermissionPrefixes(): array
-    {
-        return [
-            'view',
-            'view_any',
-            'create',
-            'update',
-            'delete',
-        ];
     }
 }

--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -6,9 +6,11 @@ use App\Concerns\HasLocales;
 use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\GenreResource\Pages;
 use App\Models\Genre;
+use App\Rules\UniqueJsonTranslation;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -28,11 +30,19 @@ class GenreResource extends Resource implements HasShieldPermissions
         return $form
             ->schema([
                 Translate::make()
-                    ->schema([
+                    ->schema(fn (string $locale): array => [
                         TextInput::make('name')
                             ->label(__('genre.resource.name'))
                             ->required()
-                            ->maxLength(255),
+                            ->maxLength(255)
+                            ->rules(function (Get $get) use ($locale) {
+                                /** @var string */
+                                $id = $get('id');
+
+                                return [
+                                    new UniqueJsonTranslation(table: 'genres', column: 'name', locale: $locale, ignoreId: $id),
+                                ];
+                            }),
                         TiptapEditor::make('description')
                             ->label(__('genre.resource.description')),
                     ])

--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Concerns\HasLocales;
+use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\GenreResource\Pages;
 use App\Models\Genre;
 use Filament\Forms\Components\TextInput;
@@ -43,17 +44,37 @@ class GenreResource extends Resource
     {
         return $table
             ->columns([
-                //
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('genre.resource.name'))
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('stories_count')
+                    ->counts('stories')
+                    ->label(__('genre.resource.stories_count'))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('genre.resource.created_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('genre.resource.updated_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 //
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    ReferenceAwareDeleteBulkAction::make(),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -6,6 +6,7 @@ use App\Concerns\HasLocales;
 use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\GenreResource\Pages;
 use App\Models\Genre;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -14,7 +15,7 @@ use Filament\Tables\Table;
 use FilamentTiptapEditor\TiptapEditor;
 use SolutionForest\FilamentTranslateField\Forms\Component\Translate;
 
-class GenreResource extends Resource
+class GenreResource extends Resource implements HasShieldPermissions
 {
     use HasLocales;
 
@@ -92,6 +93,20 @@ class GenreResource extends Resource
             'index' => Pages\ListGenres::route('/'),
             'create' => Pages\CreateGenre::route('/create'),
             'edit' => Pages\EditGenre::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            'view',
+            'view_any',
+            'create',
+            'update',
+            'delete',
         ];
     }
 }

--- a/app/Filament/Resources/GenreResource.php
+++ b/app/Filament/Resources/GenreResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\GenreResource\Pages;
+use App\Models\Genre;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class GenreResource extends Resource
+{
+    protected static ?string $model = Genre::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                //
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                //
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGenres::route('/'),
+            'create' => Pages\CreateGenre::route('/create'),
+            'edit' => Pages\EditGenre::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/GenreResource/Pages/CreateGenre.php
+++ b/app/Filament/Resources/GenreResource/Pages/CreateGenre.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\GenreResource\Pages;
+
+use App\Filament\Resources\GenreResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateGenre extends CreateRecord
+{
+    protected static string $resource = GenreResource::class;
+}

--- a/app/Filament/Resources/GenreResource/Pages/EditGenre.php
+++ b/app/Filament/Resources/GenreResource/Pages/EditGenre.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\GenreResource\Pages;
+
+use App\Filament\Resources\GenreResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditGenre extends EditRecord
+{
+    protected static string $resource = GenreResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/GenreResource/Pages/ListGenres.php
+++ b/app/Filament/Resources/GenreResource/Pages/ListGenres.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\GenreResource\Pages;
+
+use App\Filament\Resources\GenreResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListGenres extends ListRecords
+{
+    protected static string $resource = GenreResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -96,7 +96,6 @@ class StoryResource extends Resource implements HasShieldPermissions
                             Forms\Components\Select::make('genres')
                                 ->multiple()
                                 ->relationship('genres', 'name', fn (Builder $query) => $query->orderBy('name->'.app()->getLocale()))
-                                ->getOptionLabelUsing(fn (\App\Models\Genre $record): string => $record->name)
                                 ->preload()
                                 ->label(trans_choice('genre.resource.model_label', 2)),
                         ]),

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -92,6 +92,14 @@ class StoryResource extends Resource implements HasShieldPermissions
                                 ->label(__('story.resource.cover_media'))
                                 ->relationship('coverMedia', 'name'),
                         ]),
+                        Forms\Components\Section::make([
+                            Forms\Components\Select::make('genres')
+                                ->multiple()
+                                ->relationship('genres', 'name', fn (Builder $query) => $query->orderBy('name->'.app()->getLocale()))
+                                ->getOptionLabelUsing(fn (\App\Models\Genre $record): string => $record->name)
+                                ->preload()
+                                ->label(trans_choice('genre.resource.model_label', 2)),
+                        ]),
                         Creator::getComponent(static::canViewAll()),
                     ])->columnSpan([
                         'default' => 1,

--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -34,7 +34,7 @@ class Genre extends Model
     /*
      * @var string[]
      */
-    protected $guarded = [];
+    protected $fillable = ['name', 'description'];
 
     public function isReferenced(): bool
     {

--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -2,24 +2,21 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
 use Spatie\Translatable\HasTranslations;
 
 /**
  * @property string $id
  * @property string $name
  * @property string $description
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- */
-/**
- * @property string $id
- * @property string $name
- * @property string $description
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Collection<int, \App\Models\Story> $stories
  */
 class Genre extends Model
 {
@@ -38,4 +35,12 @@ class Genre extends Model
      * @var string[]
      */
     protected $guarded = [];
+
+    /**
+     * @return BelongsToMany<Story, $this>
+     */
+    public function stories(): BelongsToMany
+    {
+        return $this->belongsToMany(Story::class);
+    }
 }

--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -36,6 +36,11 @@ class Genre extends Model
      */
     protected $guarded = [];
 
+    public function isReferenced(): bool
+    {
+        return $this->stories()->exists();
+    }
+
     /**
      * @return BelongsToMany<Story, $this>
      */

--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * @property string $id
+ * @property string $name
+ * @property string $description
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+/**
+ * @property string $id
+ * @property string $name
+ * @property string $description
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class Genre extends Model
+{
+    /** @use HasFactory<\Database\Factories\GenreFactory> */
+    use HasFactory;
+
+    use HasTranslations;
+    use HasUlids;
+
+    /**
+     * @var string[]
+     */
+    public $translatable = ['name', 'description'];
+
+    /*
+     * @var string[]
+     */
+    protected $guarded = [];
+}

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -10,6 +10,7 @@ use App\Enums\Vote\Type;
 use App\Observers\StoryObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -38,6 +39,7 @@ use Spatie\Translatable\HasTranslations;
  * @property ?Carbon $updated_at
  * @property-read User $creator
  * @property-read ?Media $coverMedia
+ * @property Collection<int, \App\Models\Genre> $genres
  */
 #[ObservedBy([StoryObserver::class])]
 class Story extends Model
@@ -198,6 +200,17 @@ class Story extends Model
         }
 
         return false;
+    }
+
+    /**
+     * Get the genres associated with the story.
+     *
+     * @return BelongsToMany<Genre, $this>
+     */
+    public function genres(): BelongsToMany
+    {
+        return $this->belongsToMany(Genre::class)
+            ->withTimestamps();
     }
 
     /**

--- a/app/Policies/GenrePolicy.php
+++ b/app/Policies/GenrePolicy.php
@@ -47,6 +47,10 @@ class GenrePolicy
      */
     public function delete(User $user, Genre $genre): bool
     {
+        if ($genre->isReferenced()) {
+            return false;
+        }
+
         return $user->can('delete_genre');
     }
 }

--- a/app/Policies/GenrePolicy.php
+++ b/app/Policies/GenrePolicy.php
@@ -27,14 +27,6 @@ class GenrePolicy
     }
 
     /**
-     * Determine whether the user can view all models.
-     */
-    public function viewAll(User $user): bool
-    {
-        return $user->can('view_all_genre');
-    }
-
-    /**
      * Determine whether the user can create models.
      */
     public function create(User $user): bool

--- a/app/Policies/GenrePolicy.php
+++ b/app/Policies/GenrePolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Genre;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class GenrePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_genre');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Genre $genre): bool
+    {
+        return $user->can('view_genre');
+    }
+
+    /**
+     * Determine whether the user can view all models.
+     */
+    public function viewAll(User $user): bool
+    {
+        return $user->can('view_all_genre');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create_genre');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Genre $genre): bool
+    {
+        return $user->can('update_genre');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Genre $genre): bool
+    {
+        return $user->can('delete_genre');
+    }
+}

--- a/app/Rules/UniqueJsonTranslation.php
+++ b/app/Rules/UniqueJsonTranslation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\DB;
+
+class UniqueJsonTranslation implements ValidationRule
+{
+    protected string $table;
+    protected string $column;
+    protected string $locale;
+    protected ?string $ignoreId; // Changed to string for ULID support
+    protected string $idColumn; // To specify the ID column name
+
+    public function __construct(string $table, string $column, string $locale, ?string $ignoreId = null, string $idColumn = 'id')
+    {
+        $this->table = $table;
+        $this->column = $column;
+        $this->locale = $locale;
+        $this->ignoreId = $ignoreId;
+        $this->idColumn = $idColumn;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $query = DB::table($this->table)
+            ->where("{$this->column}->{$this->locale}", $value);
+
+        if ($this->ignoreId) {
+            $query->where($this->idColumn, '!=', $this->ignoreId);
+        }
+
+        if ($query->exists()) {
+            $fail(__('genre.unique_json_translation'));
+        }
+    }
+}

--- a/database/factories/GenreFactory.php
+++ b/database/factories/GenreFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Genre>
+ */
+class GenreFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = [
+            'en' => $this->faker->unique()->word(),
+        ];
+        $description = [
+            'en' => $this->faker->sentence(),
+        ];
+
+        return [
+            'name' => $name,
+            'description' => $description,
+        ];
+    }
+}

--- a/database/migrations/2025_09_25_102901_create_genres_table.php
+++ b/database/migrations/2025_09_25_102901_create_genres_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('genres', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->json('name');
+            $table->json('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('genres');
+    }
+};

--- a/database/migrations/2025_09_26_022521_create_genre_story_table.php
+++ b/database/migrations/2025_09_26_022521_create_genre_story_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('genre_story', function (Blueprint $table) {
+            $table->primary(['genre_id', 'story_id']);
+            $table->foreignUlid('genre_id')->constrained()->onDelete('cascade');
+            $table->foreignUlid('story_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('genre_story');
+    }
+};

--- a/lang/en/genre.php
+++ b/lang/en/genre.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'resource' => [
+        'name' => 'Name',
+        'description' => 'Description',
+        'stories_count' => 'Stories Count',
+        'created_at' => 'Created At',
+        'updated_at' => 'Updated At',
+        'model_label' => 'Genre|Genres',
+    ],
+];

--- a/lang/en/genre.php
+++ b/lang/en/genre.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 return [
+    'unique_json_translation' => 'The :attribute has already been taken for this locale.',
     'resource' => [
         'name' => 'Name',
         'description' => 'Description',

--- a/lang/id/genre.php
+++ b/lang/id/genre.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 return [
+    'unique_json_translation' => 'Atribut :attribute sudah ada untuk lokal ini.',
     'resource' => [
         'name' => 'Nama',
         'description' => 'Deskripsi',

--- a/lang/id/genre.php
+++ b/lang/id/genre.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'resource' => [
+        'name' => 'Nama',
+        'description' => 'Deskripsi',
+        'stories_count' => 'Jumlah Cerita',
+        'created_at' => 'Dibuat Pada',
+        'updated_at' => 'Diperbarui Pada',
+        'model_label' => 'Genre|Genre',
+    ],
+];

--- a/tests/Feature/Filament/Resources/GenreResourceTest.php
+++ b/tests/Feature/Filament/Resources/GenreResourceTest.php
@@ -92,6 +92,21 @@ class GenreResourceTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_user_with_only_view_permissions_cannot_create_genre(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['view_any_genre', 'view_genre']);
+        $this->actingAs($user);
+
+        // Attempt to access the create page
+        $this->get(GenreResource::getUrl('create'))
+            ->assertForbidden();
+
+        // Attempt to create a genre via Livewire
+        $livewire = Livewire::test(CreateGenre::class);
+        $livewire->assertForbidden(); // Expecting a forbidden response
+    }
+
     public function test_genre_creation_requires_name(): void
     {
         $this->actingAs($this->adminUser);

--- a/tests/Feature/Filament/Resources/GenreResourceTest.php
+++ b/tests/Feature/Filament/Resources/GenreResourceTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Filament\Resources\GenreResource;
+use App\Filament\Resources\GenreResource\Pages\CreateGenre;
+use App\Filament\Resources\GenreResource\Pages\EditGenre;
+use App\Filament\Resources\GenreResource\Pages\ListGenres;
+use App\Models\Genre;
+use App\Models\Permission;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class GenreResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $adminUser;
+
+    private User $unauthorizedUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->adminUser = User::factory()->create();
+        $this->unauthorizedUser = User::factory()->create();
+
+        // Ensure permissions exist for Genre resource
+        foreach (GenreResource::getPermissionPrefixes() as $prefix) {
+            Permission::firstOrCreate(['name' => $prefix.'_genre']);
+        }
+
+        // Assign all genre permissions to adminUser
+        $this->adminUser->givePermissionTo(collect(GenreResource::getPermissionPrefixes())->map(fn ($prefix) => $prefix.'_genre')->toArray());
+
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+    }
+
+    public function test_admin_user_can_view_list_of_genres(): void
+    {
+        $this->actingAs($this->adminUser);
+        Genre::factory()->count(3)->create();
+
+        Livewire::test(ListGenres::class)
+            ->assertCanSeeTableRecords(Genre::all());
+    }
+
+    public function test_unauthorized_user_cannot_view_list_of_genres(): void
+    {
+        $this->actingAs($this->unauthorizedUser);
+        Genre::factory()->count(3)->create();
+
+        $this->get(GenreResource::getUrl('index'))
+            ->assertForbidden();
+    }
+
+    public function test_admin_user_can_create_genre(): void
+    {
+        $this->actingAs($this->adminUser);
+
+        $livewire = Livewire::test(CreateGenre::class);
+        $livewire->fillForm([
+            'name' => [
+                'en' => 'Test Genre EN',
+                'id' => 'Test Genre ID',
+            ],
+            'description' => [
+                'en' => 'Test Description EN',
+                'id' => 'Test Description ID',
+            ],
+        ]);
+        $livewire->call('create');
+        $livewire->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('genres', [
+            'name' => json_encode([
+                'en' => 'Test Genre EN',
+                'id' => 'Test Genre ID',
+            ]),
+            'description' => '{"en":"<p>Test Description EN</p>","id":"<p>Test Description ID</p>"}',
+        ]);
+    }
+
+    public function test_unauthorized_user_cannot_create_genre(): void
+    {
+        $this->actingAs($this->unauthorizedUser);
+
+        $this->get(GenreResource::getUrl('create'))
+            ->assertForbidden();
+    }
+
+    public function test_genre_creation_requires_name(): void
+    {
+        $this->actingAs($this->adminUser);
+
+        $livewire = Livewire::test(CreateGenre::class);
+        $livewire->fillForm([
+            'name' => [
+                'en' => '',
+                'id' => '',
+            ],
+            'description' => [
+                'en' => 'Some description',
+                'id' => 'Some description',
+            ],
+        ]);
+        $livewire->call('create');
+        $livewire->assertHasFormErrors([
+            'name.en' => 'required',
+            'name.id' => 'required',
+        ]);
+    }
+
+    public function test_admin_user_can_update_genre(): void
+    {
+        $this->actingAs($this->adminUser);
+        $genre = Genre::factory()->create([
+            'name' => [
+                'en' => 'Original Name EN',
+                'id' => 'Original Name ID',
+            ],
+            'description' => [
+                'en' => 'Original Description EN',
+                'id' => 'Original Description ID',
+            ],
+        ]);
+
+        $livewire = Livewire::test(EditGenre::class, ['record' => $genre->getRouteKey()]);
+        $livewire->fillForm([
+            'name' => [
+                'en' => 'Updated Name EN',
+                'id' => 'Updated Name ID',
+            ],
+            'description' => [
+                'en' => 'Updated Description EN',
+                'id' => 'Updated Description ID',
+            ],
+        ]);
+        $livewire->call('save');
+        $livewire->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('genres', [
+            'id' => $genre->id,
+            'name' => json_encode([
+                'en' => 'Updated Name EN',
+                'id' => 'Updated Name ID',
+            ]),
+            'description' => '{"en":"<p>Updated Description EN</p>","id":"<p>Updated Description ID</p>"}',
+        ]);
+    }
+
+    public function test_unauthorized_user_cannot_update_genre(): void
+    {
+        $this->actingAs($this->unauthorizedUser);
+        $genre = Genre::factory()->create();
+
+        $this->get(GenreResource::getUrl('edit', ['record' => $genre->getRouteKey()]))
+            ->assertForbidden();
+    }
+
+    public function test_genre_update_requires_name(): void
+    {
+        $this->actingAs($this->adminUser);
+        $genre = Genre::factory()->create([
+            'name' => [
+                'en' => 'Original Name EN',
+                'id' => 'Original Name ID',
+            ],
+        ]);
+
+        $livewire = Livewire::test(EditGenre::class, ['record' => $genre->getRouteKey()]);
+        $livewire->fillForm([
+            'name' => [
+                'en' => '',
+                'id' => '',
+            ],
+        ]);
+        $livewire->call('save');
+        $livewire->assertHasFormErrors([
+            'name.en' => 'required',
+            'name.id' => 'required',
+        ]);
+    }
+
+    public function test_admin_user_can_delete_genre(): void
+    {
+        $this->actingAs($this->adminUser);
+        $genre = Genre::factory()->create();
+
+        Livewire::test(EditGenre::class, ['record' => $genre->getRouteKey()])
+            ->call('mountAction', 'delete')
+            ->call('callMountedAction');
+
+        $this->assertDatabaseMissing('genres', [
+            'id' => $genre->id,
+        ]);
+    }
+
+    public function test_admin_user_can_bulk_delete_genres(): void
+    {
+        $this->actingAs($this->adminUser);
+        $genres = Genre::factory()->count(3)->create();
+
+        Livewire::test(ListGenres::class)
+            ->callTableBulkAction('delete', $genres);
+
+        foreach ($genres as $genre) {
+            $this->assertDatabaseMissing('genres', [
+                'id' => $genre->id,
+            ]);
+        }
+    }
+}

--- a/tests/Unit/Models/GenreTest.php
+++ b/tests/Unit/Models/GenreTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Genre;
+use App\Models\Story;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Tests\TestCase;
+
+class GenreTest extends TestCase
+{
+    /**
+     * Test that the genre has many stories.
+     *
+     * @return void
+     */
+    public function test_genre_has_many_stories()
+    {
+        $genre = new Genre;
+        $this->assertInstanceOf(BelongsToMany::class, $genre->stories());
+        $this->assertInstanceOf(Story::class, $genre->stories()->getRelated());
+        $this->assertEquals('genre_story', $genre->stories()->getTable());
+        $this->assertEquals('genre_id', $genre->stories()->getForeignPivotKeyName());
+        $this->assertEquals('story_id', $genre->stories()->getRelatedPivotKeyName());
+    }
+}

--- a/tests/Unit/Models/StoryTest.php
+++ b/tests/Unit/Models/StoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Genre;
+use App\Models\Story;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_story_can_have_many_genres(): void
+    {
+        $story = Story::factory()->create();
+        $genre = Genre::factory()->create();
+
+        $story->genres()->attach($genre);
+
+        $this->assertInstanceOf(BelongsToMany::class, $story->genres());
+        $this->assertInstanceOf(Genre::class, $story->genres->first());
+        $this->assertEquals(1, $story->genres->count());
+    }
+
+    public function test_genres_relationship_is_correctly_defined(): void
+    {
+        $story = new Story;
+        $relation = $story->genres();
+
+        $this->assertInstanceOf(BelongsToMany::class, $relation);
+        $this->assertEquals('genres', $relation->getRelationName());
+        $this->assertEquals('genre_story', $relation->getTable());
+        $this->assertEquals('story_id', $relation->getForeignPivotKeyName());
+        $this->assertEquals('genre_id', $relation->getRelatedPivotKeyName());
+        $this->assertEquals(Genre::class, $relation->getRelated()->getMorphClass());
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive genre management system, enabling the classification and organization of stories. It includes a full CRUD interface within the Filament admin panel, complete with authorization, validation, and internationalization.

### Key Features

- **Database and Models**:

  - Introduced `genres` and `genre_story` pivot tables to establish a many-to-many relationship between genres and stories.
  - Created the `Genre` Eloquent model with `ULID` primary keys and support for translatable `name` and `description` fields.
  - Explicitly defined `$fillable` attributes on the `Genre` model for enhanced mass assignment security.

- **Filament Resource (`GenreResource`)**:

  - A complete Filament resource for creating, reading, updating, and deleting genres.
  - The resource form includes translatable fields for `name` (TextInput) and `description` (TiptapEditor), allowing for multilingual content entry.
  - The resource table is enhanced with columns for story count, creation, and update timestamps, along with improved row and bulk actions.

- **Authorization and Security**:

  - A `GenrePolicy` has been added to define authorization rules for all genre-related actions.
  - Integrated with `FilamentShield` to manage permissions for the `GenreResource`.
  - Implemented a deletion constraint to prevent the removal of genres that are currently associated with stories, ensuring data integrity.

- **Validation**:

  - A custom `UniqueJsonTranslation` validation rule ensures that genre names are unique for each locale.
  - The `name` field is now conditionally required, improving flexibility by allowing blank translations as long as at least one locale is filled.

- **Integration and Internationalization**:

  - The `StoryResource` form has been updated with a multiple select field to associate stories with one or more genres.
  - Added English and Indonesian translation files (`lang/{en,id}/genre.php`) to provide full i18n support for labels, validation messages, and navigation elements.

- **Testing**:
  - Added a comprehensive suite of tests to ensure the reliability and correctness of the new feature:
    - **Feature tests** for `GenreResource` covering all CRUD operations, authorization, validation rules, and deletion constraints.
    - **Feature tests** for `StoryResource` to verify that genres can be correctly attached, detached, and synced with stories.
    - **Unit tests** for the `Genre` and `Story` models to validate the `BelongsToMany` relationships.