### PR TITLE
feat: implement age rating system and content restriction

### DIFF
--- a/app/Filament/Resources/AgeRatingResource.php
+++ b/app/Filament/Resources/AgeRatingResource.php
@@ -2,51 +2,72 @@
 
 namespace App\Filament\Resources;
 
+use App\Concerns\HasLocales;
+use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\AgeRatingResource\Pages;
 use App\Models\AgeRating;
+use App\Rules\UniqueJsonTranslation;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use FilamentTiptapEditor\TiptapEditor;
+use SolutionForest\FilamentTranslateField\Forms\Component\Translate;
 
-class AgeRatingResource extends Resource
+class AgeRatingResource extends Resource implements HasShieldPermissions
 {
+    use HasLocales;
+
     protected static ?string $model = AgeRating::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                //
+                Translate::make()
+                    ->schema(function (string $locale): array {
+                        return [
+                            TextInput::make('name')
+                                ->label(__('age_rating.resource.name'))
+                                ->required($locale === config('app.locale'))
+                                ->maxLength(255)
+                                ->rules(function (Get $get) use ($locale) {
+                                    /** @var string */
+                                    $id = $get('id');
+
+                                    return [
+                                        new UniqueJsonTranslation(table: 'age_ratings', column: 'name', locale: $locale, ignoreId: $id),
+                                    ];
+                                }),
+                            TiptapEditor::make('description')
+                                ->label(__('age_rating.resource.description')),
+                        ];
+                    })
+                    ->columnSpanFull()
+                    ->locales(static::getSortedLocales())
+                    ->suffixLocaleLabel(),
+                TextInput::make('age_representation')
+                    ->label(__('age_rating.resource.age_representation'))
+                    ->required()
+                    ->integer()
+                    ->minValue(0)
+                    ->columnSpanFull(),
             ]);
     }
 
-    public static function table(Table $table): Table
+    public static function getModelLabel(): string
     {
-        return $table
-            ->columns([
-                //
-            ])
-            ->filters([
-                //
-            ])
-            ->actions([
-                Tables\Actions\EditAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
-                ]),
-            ]);
+        return trans_choice('age_rating.resource.model_label', 1);
     }
 
-    public static function getRelations(): array
+    public static function getNavigationGroup(): ?string
     {
-        return [
-            //
-        ];
+        return __('Administration');
     }
 
     public static function getPages(): array
@@ -56,5 +77,61 @@ class AgeRatingResource extends Resource
             'create' => Pages\CreateAgeRating::route('/create'),
             'edit' => Pages\EditAgeRating::route('/{record}/edit'),
         ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            'view',
+            'view_any',
+            'create',
+            'update',
+            'delete',
+        ];
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans_choice('age_rating.resource.model_label', 2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('age_rating.resource.name'))
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('age_representation')
+                    ->label(__('age_rating.resource.age_representation'))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('stories_count')
+                    ->counts('stories')
+                    ->label(__('age_rating.resource.stories_count'))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('age_rating.resource.created_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('age_rating.resource.updated_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
+            ]);
     }
 }

--- a/app/Filament/Resources/AgeRatingResource.php
+++ b/app/Filament/Resources/AgeRatingResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\AgeRatingResource\Pages;
+use App\Models\AgeRating;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class AgeRatingResource extends Resource
+{
+    protected static ?string $model = AgeRating::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                //
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                //
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListAgeRatings::route('/'),
+            'create' => Pages\CreateAgeRating::route('/create'),
+            'edit' => Pages\EditAgeRating::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/AgeRatingResource.php
+++ b/app/Filament/Resources/AgeRatingResource.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\AgeRatingResource\Pages;
 use App\Models\AgeRating;
 use App\Rules\UniqueJsonTranslation;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -51,12 +52,14 @@ class AgeRatingResource extends Resource implements HasShieldPermissions
                     ->columnSpanFull()
                     ->locales(static::getSortedLocales())
                     ->suffixLocaleLabel(),
-                TextInput::make('age_representation')
-                    ->label(__('age_rating.resource.age_representation'))
-                    ->required()
-                    ->integer()
-                    ->minValue(0)
-                    ->columnSpanFull(),
+                Section::make([
+                    TextInput::make('age_representation')
+                        ->label(__('age_rating.resource.age_representation'))
+                        ->required()
+                        ->integer()
+                        ->minValue(0)
+                        ->columnSpanFull(),
+                ]),
             ]);
     }
 

--- a/app/Filament/Resources/AgeRatingResource/Pages/CreateAgeRating.php
+++ b/app/Filament/Resources/AgeRatingResource/Pages/CreateAgeRating.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\AgeRatingResource\Pages;
+
+use App\Filament\Resources\AgeRatingResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAgeRating extends CreateRecord
+{
+    protected static string $resource = AgeRatingResource::class;
+}

--- a/app/Filament/Resources/AgeRatingResource/Pages/EditAgeRating.php
+++ b/app/Filament/Resources/AgeRatingResource/Pages/EditAgeRating.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AgeRatingResource\Pages;
+
+use App\Filament\Resources\AgeRatingResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAgeRating extends EditRecord
+{
+    protected static string $resource = AgeRatingResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AgeRatingResource/Pages/ListAgeRatings.php
+++ b/app/Filament/Resources/AgeRatingResource/Pages/ListAgeRatings.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AgeRatingResource\Pages;
+
+use App\Filament\Resources\AgeRatingResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAgeRatings extends ListRecords
+{
+    protected static string $resource = AgeRatingResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -242,6 +242,17 @@ class StoryResource extends Resource implements HasShieldPermissions
                     ReferenceAwareDeleteBulkAction::make(),
                 ]),
             ])
+            ->filters([
+                Tables\Filters\TernaryFilter::make('age_rating_effective_value')
+                    ->label(__('story.resource.rating_status'))
+                    ->trueLabel(__('story.resource.awaiting_rating'))
+                    ->falseLabel(__('story.resource.rated_stories'))
+                    ->queries(
+                        true: fn (Builder $query) => $query->whereNull('age_rating_effective_value'),
+                        false: fn (Builder $query) => $query->whereNotNull('age_rating_effective_value'),
+                        blank: fn (Builder $query) => $query,
+                    ),
+            ])
             ->recordUrl(fn (Story $record) => route('filament.admin.resources.stories.edit', $record));
     }
 }

--- a/app/Filament/Resources/StoryResource.php
+++ b/app/Filament/Resources/StoryResource.php
@@ -115,6 +115,15 @@ class StoryResource extends Resource implements HasShieldPermissions
                                 ->searchable()
                                 ->label(trans_choice('license.resource.model_label', 2)),
                         ]),
+                        Forms\Components\Section::make([
+                            Forms\Components\Select::make('ageRatings')
+                                ->multiple()
+                                ->relationship('ageRatings', 'name', fn (Builder $query) => $query->orderBy('name->'.app()->getLocale()))
+                                ->preload()
+                                ->searchable()
+                                ->label(trans_choice('age_rating.resource.model_label', 2))
+                                ->hidden(! static::canViewAll()),
+                        ]),
                         Creator::getComponent(static::canViewAll()),
                     ])->columnSpan([
                         'default' => 1,

--- a/app/Http/Middleware/RedirectRestrictedContent.php
+++ b/app/Http/Middleware/RedirectRestrictedContent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Story;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectRestrictedContent
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Auth::guest()) {
+            // Check if the request is for a specific story
+            if ($request->route('story')) {
+                $story = $request->route('story');
+
+                if ($story instanceof Story) {
+                    $guestAgeLimit = Config::get('age_rating.guest_limit_years', 16);
+
+                    if (is_null($story->age_rating_effective_value) || $story->age_rating_effective_value > $guestAgeLimit) {
+                        // Store the intended URL before redirecting to login
+                        return redirect()->route('login', ['next' => $request->fullUrl()]);
+                    }
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RedirectRestrictedContent.php
+++ b/app/Http/Middleware/RedirectRestrictedContent.php
@@ -26,7 +26,7 @@ class RedirectRestrictedContent
                 if ($story instanceof Story) {
                     $guestAgeLimit = Config::get('age_rating.guest_limit_years', 16);
 
-                    if (is_null($story->age_rating_effective_value) || $story->age_rating_effective_value > $guestAgeLimit) {
+                    if (is_null($story->age_rating_effective_value) || $story->age_rating_effective_value >= $guestAgeLimit) {
                         // Store the intended URL before redirecting to login
                         return redirect()->route('login', ['next' => $request->fullUrl()]);
                     }

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Laravel\Fortify\Http\Responses\LoginResponse as FortifyLoginResponse;
+
+class LoginResponse extends FortifyLoginResponse
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        if ($request->wantsJson()) {
+            return parent::toResponse($request);
+        }
+
+        if ($request->has('next')) {
+            /** @var ?string */
+            $url = $request->input('next');
+
+            if ($url) {
+                /** @var string */
+                $appUrl = config('app.url');
+                $appHost = parse_url($appUrl, PHP_URL_HOST);
+                $checkHost = parse_url($url, PHP_URL_HOST);
+
+                if ($appHost !== null && $checkHost !== null && $appHost === $checkHost) {
+                    return redirect($url);
+                }
+            }
+        }
+
+        return parent::toResponse($request);
+    }
+}

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Auth;
 
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -30,7 +31,13 @@ class Login extends Component implements HasForms
 
     public function mount(): void
     {
-        $this->form->fill();
+        $data = [];
+
+        if (request()->has('next')) {
+            $data['next'] = request()->input('next');
+        }
+
+        $this->form->fill($data);
     }
 
     public function form(Form $form): Form
@@ -59,6 +66,8 @@ class Login extends Component implements HasForms
                         Checkbox::make('remember')
                             ->label(__('Remember me'))
                             ->extraInputAttributes(['name' => 'remember']),
+                        Hidden::make('next')
+                            ->extraAttributes(['name' => 'next']),
                     ])
                     ->footerActions(array_filter([
                         Action::make('login')

--- a/app/Livewire/Story/Concerns/HasStoryTable.php
+++ b/app/Livewire/Story/Concerns/HasStoryTable.php
@@ -3,8 +3,10 @@
 namespace App\Livewire\Story\Concerns;
 
 use App\Models\Story;
+use App\Scopes\GuestStoryFilterScope;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
 
 trait HasStoryTable
 {
@@ -14,6 +16,10 @@ trait HasStoryTable
     protected function getStoryTable(Table $table): Table
     {
         $query = Story::published();
+
+        if (Auth::guest()) {
+            $query->withGlobalScope('guest_filter', new GuestStoryFilterScope);
+        }
 
         return $table
             ->query($query)

--- a/app/Models/AgeRating.php
+++ b/app/Models/AgeRating.php
@@ -21,8 +21,8 @@ class AgeRating extends Model
 {
     /** @use HasFactory<\Database\Factories\AgeRatingFactory> */
     use HasFactory;
-    use HasTranslations;
 
+    use HasTranslations;
     use HasUlids;
 
     /**
@@ -51,6 +51,14 @@ class AgeRating extends Model
     protected $casts = [
         'age_representation' => 'integer',
     ];
+
+    /**
+     * Determine if the age rating is referenced by any stories.
+     */
+    public function isReferenced(): bool
+    {
+        return $this->stories()->exists();
+    }
 
     /**
      * Get the stories associated with the age rating.

--- a/app/Models/AgeRating.php
+++ b/app/Models/AgeRating.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
+use Spatie\Translatable\HasTranslations;
 
 /**
  * @property string $id
@@ -17,7 +19,38 @@ use Illuminate\Support\Carbon;
  */
 class AgeRating extends Model
 {
+    /** @use HasFactory<\Database\Factories\AgeRatingFactory> */
+    use HasFactory;
+    use HasTranslations;
+
     use HasUlids;
+
+    /**
+     * The attributes that are translatable.
+     *
+     * @var array<int, string>
+     */
+    public array $translatable = ['name', 'description'];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'description',
+        'age_representation',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'age_representation' => 'integer',
+    ];
 
     /**
      * Get the stories associated with the age rating.

--- a/app/Models/AgeRating.php
+++ b/app/Models/AgeRating.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $name
+ * @property string $description
+ * @property int $age_representation
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class AgeRating extends Model
+{
+    use HasUlids;
+
+    /**
+     * Get the stories associated with the age rating.
+     *
+     * @return BelongsToMany<Story, $this>
+     */
+    public function stories(): BelongsToMany
+    {
+        return $this->belongsToMany(Story::class, 'age_rating_story');
+    }
+}

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -8,6 +8,7 @@ use App\Constants\VotingConstants;
 use App\Enums\Story\Status;
 use App\Enums\Vote\Type;
 use App\Observers\StoryObserver;
+use App\Scopes\GuestStoryFilterScope;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -52,6 +53,14 @@ class Story extends Model
 
     use HasTranslations;
     use HasUlids;
+
+    /**
+     * The "booted" method of the model.
+     */
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new GuestStoryFilterScope);
+    }
 
     /**
      * @var array<int, string>

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -86,6 +86,16 @@ class Story extends Model
     ];
 
     /**
+     * Get the age ratings associated with the story.
+     *
+     * @return BelongsToMany<AgeRating, $this>
+     */
+    public function ageRatings(): BelongsToMany
+    {
+        return $this->belongsToMany(AgeRating::class, 'age_rating_story');
+    }
+
+    /**
      * Get the storyComments for the story.
      *
      * @return HasMany<StoryComment, $this>

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -8,7 +8,6 @@ use App\Constants\VotingConstants;
 use App\Enums\Story\Status;
 use App\Enums\Vote\Type;
 use App\Observers\StoryObserver;
-use App\Scopes\GuestStoryFilterScope;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -53,14 +52,6 @@ class Story extends Model
 
     use HasTranslations;
     use HasUlids;
-
-    /**
-     * The "booted" method of the model.
-     */
-    protected static function booted(): void
-    {
-        static::addGlobalScope(new GuestStoryFilterScope);
-    }
 
     /**
      * @var array<int, string>

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -71,6 +71,7 @@ class Story extends Model
         'vote_count' => 'integer',
         'vote_score' => 'float',
         'comment_count' => 'integer',
+        'age_rating_effective_value' => 'integer',
     ];
 
     /**

--- a/app/Observers/StoryObserver.php
+++ b/app/Observers/StoryObserver.php
@@ -24,7 +24,7 @@ class StoryObserver
     {
         // Load age ratings if not already loaded, or if the relationship might have changed
         // This ensures we have the latest ratings, especially if they were just synced.
-        $story->loadMissing('ageRatings');
+        $story->load('ageRatings');
 
         /** @var ?int */
         $maxAgeRepresentation = $story->ageRatings->max('age_representation');

--- a/app/Observers/StoryObserver.php
+++ b/app/Observers/StoryObserver.php
@@ -9,6 +9,30 @@ use Locale;
 
 class StoryObserver
 {
+    /**
+     * Handle the Story "saving" event.
+     */
+    public function saving(Story $story): void
+    {
+        $this->calculateEffectiveAgeRating($story);
+    }
+
+    /**
+     * Calculate the effective age rating for the story.
+     */
+    protected function calculateEffectiveAgeRating(Story $story): void
+    {
+        // Load age ratings if not already loaded, or if the relationship might have changed
+        // This ensures we have the latest ratings, especially if they were just synced.
+        $story->loadMissing('ageRatings');
+
+        /** @var ?int */
+        $maxAgeRepresentation = $story->ageRatings->max('age_representation');
+
+        // Set the effective value. If no ratings, max() returns null.
+        $story->age_rating_effective_value = $maxAgeRepresentation;
+    }
+
     public function saved(Story $story): void
     {
         // Only run the sync logic if the content field has been changed.

--- a/app/Policies/AgeRatingPolicy.php
+++ b/app/Policies/AgeRatingPolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AgeRating;
+use App\Models\User;
+
+class AgeRatingPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_age::rating');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, AgeRating $ageRating): bool
+    {
+        return $user->can('view_age::rating');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create_age::rating');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, AgeRating $ageRating): bool
+    {
+        return $user->can('update_age::rating');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, AgeRating $ageRating): bool
+    {
+        if ($ageRating->isReferenced()) {
+            return false;
+        }
+
+        return $user->can('delete_age::rating');
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -6,11 +6,13 @@ use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
+use App\Http\Responses\LoginResponse;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -20,7 +22,8 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+
+        $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
     }
 
     /**

--- a/app/Scopes/GuestStoryFilterScope.php
+++ b/app/Scopes/GuestStoryFilterScope.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Scopes;
+
+use App\Models\Story;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+
+class GuestStoryFilterScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  Builder<Story>  $builder
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        if (Auth::guest()) {
+            $guestAgeLimit = Config::get('age_rating.guest_limit_years', 16);
+            $builder->whereNotNull('age_rating_effective_value')
+                ->where('age_rating_effective_value', '<=', $guestAgeLimit);
+        }
+    }
+}

--- a/app/Scopes/GuestStoryFilterScope.php
+++ b/app/Scopes/GuestStoryFilterScope.php
@@ -21,7 +21,7 @@ class GuestStoryFilterScope implements Scope
         if (Auth::guest()) {
             $guestAgeLimit = Config::get('age_rating.guest_limit_years', 16);
             $builder->whereNotNull('age_rating_effective_value')
-                ->where('age_rating_effective_value', '<=', $guestAgeLimit);
+                ->where('age_rating_effective_value', '<', $guestAgeLimit);
         }
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\EnsureJsonRequest;
+use App\Http\Middleware\RedirectRestrictedContent;
 use App\Http\Middleware\SetDeviceFromHeader;
 use App\Http\Middleware\SetLocaleFromHeader;
 use App\Http\Middleware\SetLocaleFromQueryAndSession;
@@ -22,7 +23,10 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(ProtectAgainstSpam::class);
         $middleware->append(SetDeviceFromHeader::class);
         $middleware->append(SetLocaleFromHeader::class);
-        $middleware->web(append: [SetLocaleFromQueryAndSession::class]);
+        $middleware->web(append: [
+            SetLocaleFromQueryAndSession::class,
+            RedirectRestrictedContent::class,
+        ]);
         $middleware->statefulApi();
 
         $middleware->alias([

--- a/config/age_rating.php
+++ b/config/age_rating.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Age Rating Guest Limit Years
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the maximum age rating (in years) that a guest
+    | user can view. Stories with an effective age rating higher than this
+    | value will be filtered out for unauthenticated users.
+    |
+    | If not set in the .env file, the default value of 16 will be used.
+    |
+    */
+
+    'guest_limit_years' => env('AGE_RATING_GUEST_LIMIT_YEARS', 16),
+];

--- a/database/factories/AgeRatingFactory.php
+++ b/database/factories/AgeRatingFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AgeRating;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<AgeRating>
+ */
+class AgeRatingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => [
+                'en' => $this->faker->unique()->sentence(2, true),
+                'es' => $this->faker->unique()->sentence(2, true),
+            ],
+            'description' => [
+                'en' => $this->faker->paragraph(1),
+                'es' => $this->faker->paragraph(1),
+            ],
+            'age_representation' => $this->faker->numberBetween(0, 18),
+        ];
+    }
+}

--- a/database/migrations/2025_10_30_014108_create_age_ratings_table.php
+++ b/database/migrations/2025_10_30_014108_create_age_ratings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('age_ratings', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->json('name');
+            $table->json('description');
+            $table->unsignedInteger('age_representation');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('age_ratings');
+    }
+};

--- a/database/migrations/2025_10_30_014559_create_age_rating_story_table.php
+++ b/database/migrations/2025_10_30_014559_create_age_rating_story_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('age_rating_story', function (Blueprint $table) {
+            $table->primary(['age_rating_id', 'story_id']);
+            $table->foreignUlid('age_rating_id')->constrained()->onDelete('cascade');
+            $table->foreignUlid('story_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('age_rating_story');
+    }
+};

--- a/database/migrations/2025_10_30_015539_add_age_rating_effective_value_to_stories_table.php
+++ b/database/migrations/2025_10_30_015539_add_age_rating_effective_value_to_stories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            $table->unsignedInteger('age_rating_effective_value')
+                ->nullable()
+                ->after('comment_count')
+                ->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            $table->dropColumn('age_rating_effective_value');
+        });
+    }
+};

--- a/lang/en/age_rating.php
+++ b/lang/en/age_rating.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'resource' => [
+        'name' => 'Name',
+        'description' => 'Description',
+        'age_representation' => 'Age Representation',
+        'stories_count' => 'Stories Count',
+        'created_at' => 'Created At',
+        'updated_at' => 'Updated At',
+        'model_label' => 'Age Rating|Age Ratings',
+    ],
+];

--- a/lang/en/story.php
+++ b/lang/en/story.php
@@ -18,6 +18,9 @@ return [
             'publish' => 'Publish',
         ],
         'title' => 'Title',
+        'awaiting_rating' => 'Awaiting Rating',
+        'rated_stories' => 'Rated Stories',
+        'rating_status' => 'Rating Status',
     ],
     'table' => [
         'view_all' => 'View All Stories',

--- a/lang/id/age_rating.php
+++ b/lang/id/age_rating.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'resource' => [
+        'name' => 'Nama',
+        'description' => 'Deskripsi',
+        'age_representation' => 'Representasi Usia',
+        'stories_count' => 'Jumlah Cerita',
+        'created_at' => 'Dibuat Pada',
+        'updated_at' => 'Diperbarui Pada',
+        'model_label' => 'Rating Usia|Rating Usia',
+    ],
+];

--- a/lang/id/story.php
+++ b/lang/id/story.php
@@ -18,6 +18,9 @@ return [
             'publish' => 'Terbit',
         ],
         'title' => 'Judul',
+        'awaiting_rating' => 'Menunggu Penilaian',
+        'rated_stories' => 'Cerita Dinilai',
+        'rating_status' => 'Status Penilaian',
     ],
     'table' => [
         'view_all' => 'Lihat Semua Cerita',

--- a/tests/Feature/E2E/AgeRatingWorkflowTest.php
+++ b/tests/Feature/E2E/AgeRatingWorkflowTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Filament\E2E;
+
+use App\Filament\Resources\AgeRatingResource;
+use App\Filament\Resources\StoryResource;
+use App\Models\AgeRating;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AgeRatingWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // --- Setup Spatie Permissions and Users ---
+        $adminRole = Role::create(['name' => 'admin']);
+
+        // Create permissions for admin (age ratings and stories)
+        Permission::create(['name' => 'view_any_age::rating']);
+        Permission::create(['name' => 'create_age::rating']);
+        Permission::create(['name' => 'update_age::rating']);
+        Permission::create(['name' => 'delete_age::rating']);
+
+        Permission::create(['name' => 'view_any_story']);
+        Permission::create(['name' => 'view_all_story']);
+        Permission::create(['name' => 'create_story']);
+        Permission::create(['name' => 'update_story']);
+        Permission::create(['name' => 'delete_story']);
+
+        $adminRole->givePermissionTo(Permission::all());
+
+        // Create admin user
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole($adminRole);
+    }
+
+    public function test_complete_age_rating_workflow_e2e_test(): void
+    {
+        // 0. Initial Setup: Create a story that will be edited and guest limit years.
+        /** @var Story */
+        $story = Story::factory()->create([
+            'creator_id' => $this->adminUser->id, // Admin is creator for simplicity
+        ]);
+        Config::set('age_rating.guest_limit_years', 17);
+
+        // --- 1. Admin creates a new age rating ---
+        $this->actingAs($this->adminUser);
+        $ageRatingName = ['en' => 'Adults Only', 'fr' => 'Adultes Seulement'];
+        $ageRatingValue = 18; // Example value
+
+        $livewire = Livewire::test(AgeRatingResource\Pages\CreateAgeRating::class);
+        $livewire->fillForm([
+            'name' => $ageRatingName,
+            'age_representation' => $ageRatingValue,
+        ]);
+        $livewire->call('create');
+        $livewire->assertHasNoErrors();
+
+        $newAgeRating = AgeRating::whereJsonContains('name', ['en' => 'Adults Only'])->firstOrFail();
+        $this->assertEquals($ageRatingValue, $newAgeRating->age_representation);
+
+        // --- 2. Admin assigns the new age rating to the story ---
+        $this->actingAs($this->adminUser);
+
+        // Check the story has no age ratings initially
+        $this->assertCount(0, $story->ageRatings);
+        $this->assertNull($story->age_rating_effective_value);
+
+        $livewire = Livewire::test(StoryResource\Pages\EditStory::class, ['record' => $story->id]);
+        $livewire->fillForm([
+            'ageRatings' => [$newAgeRating->id],
+        ]);
+        $livewire->call('save');
+        $livewire->assertHasNoErrors();
+
+        // Re-fetch the story model from the database and assert the age rating is attached and effective value updated
+        $story->refresh();
+        $this->assertCount(1, $story->ageRatings);
+
+        // --- 3. Guest user verification: Story with age rating above limit years should be inaccessible ---
+        Auth::logout();
+        $this->assertGuest(); // Ensure no user is authenticated
+
+        // Attempt to access the story's public URL (assuming a 'story.show' route exists)
+        // This part needs to be adapted based on how stories are publicly viewed.
+        // For now, we'll simulate a direct HTTP GET request.
+        $response = $this->get(route('stories.show', $story)); // Assuming 'story.show' route
+
+        // Assert redirection to login page
+        $response->assertRedirect(route('login', [
+            'next' => route('stories.show', $story),
+        ])); // Assuming Filament's login route
+    }
+}

--- a/tests/Feature/Filament/Resources/AgeRatingResourceTest.php
+++ b/tests/Feature/Filament/Resources/AgeRatingResourceTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Filament\Resources\AgeRatingResource;
+use App\Filament\Resources\AgeRatingResource\Pages\CreateAgeRating;
+use App\Filament\Resources\AgeRatingResource\Pages\EditAgeRating;
+use App\Filament\Resources\AgeRatingResource\Pages\ListAgeRatings;
+use App\Models\AgeRating;
+use App\Models\Story;
+use App\Models\User;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AgeRatingResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $adminUser;
+
+    private User $unauthorizedUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create the users
+        $this->adminUser = User::factory()->create();
+        $this->unauthorizedUser = User::factory()->create();
+
+        Config::set('auth.super_users', [$this->adminUser->email]);
+
+        // Set the Filament panel context
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+    }
+
+    // --- Policy Enforcement Tests (Non-Admin Users) ---
+
+    public function test_unauthorized_user_cannot_access_age_rating_list_page(): void
+    {
+        $this->actingAs($this->unauthorizedUser)
+            ->get(AgeRatingResource::getUrl('index'))
+            ->assertForbidden();
+    }
+
+    public function test_unauthorized_user_cannot_access_age_rating_create_page(): void
+    {
+        $this->actingAs($this->unauthorizedUser)
+            ->get(AgeRatingResource::getUrl('create'))
+            ->assertForbidden();
+    }
+
+    public function test_unauthorized_user_cannot_access_age_rating_edit_page(): void
+    {
+        $ageRating = AgeRating::factory()->create();
+
+        $this->actingAs($this->unauthorizedUser)
+            ->get(AgeRatingResource::getUrl('edit', ['record' => $ageRating]))
+            ->assertForbidden();
+    }
+
+    // --- CRUD Tests (Admin Users) ---
+
+    public function test_admin_can_view_age_rating_list(): void
+    {
+        $ageRatings = AgeRating::factory(3)->create();
+
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(ListAgeRatings::class);
+        $livewire->assertCanSeeTableRecords($ageRatings);
+        $livewire->assertSuccessful();
+    }
+
+    public function test_admin_can_create_an_age_rating(): void
+    {
+        $this->actingAs($this->adminUser);
+
+        $data = [
+            'name' => [
+                'en' => 'Test Age Rating EN '.Str::random(5),
+                'id' => 'Peringkat Usia Uji ID '.Str::random(5),
+            ],
+            'description' => [
+                'en' => '<p>Test Description EN</p>',
+                'id' => '<p>Deskripsi Uji ID</p>',
+            ],
+            'age_representation' => rand(1, 18),
+        ];
+
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(CreateAgeRating::class);
+        $livewire->fillForm($data);
+        $livewire->call('create');
+        $livewire->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('age_ratings', [
+            'name' => json_encode($data['name'], JSON_UNESCAPED_SLASHES),
+            'description' => json_encode($data['description'], JSON_UNESCAPED_SLASHES),
+            'age_representation' => $data['age_representation'],
+        ]);
+    }
+
+    public function test_admin_can_edit_an_age_rating(): void
+    {
+        $ageRating = AgeRating::factory()->create([
+            'name' => ['en' => 'Old Name', 'id' => 'Nama Lama'],
+            'description' => [
+                'en' => '<p>Description EN</p>',
+                'id' => '<p>Deskripsi ID</p>',
+            ],
+            'age_representation' => 10,
+        ]);
+
+        $this->actingAs($this->adminUser);
+
+        $newData = [
+            'name' => [
+                'en' => 'New Name EN '.Str::random(5),
+                'id' => 'Nama Baru ID '.Str::random(5),
+            ],
+            'description' => [
+                'en' => '<p>Updated Description EN</p>',
+                'id' => '<p>Deskripsi Diperbarui ID</p>',
+            ],
+            'age_representation' => 15,
+        ];
+
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(EditAgeRating::class, ['record' => $ageRating->id]);
+        $livewire->fillForm($newData);
+        $livewire->call('save');
+        $livewire->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('age_ratings', [
+            'id' => $ageRating->id,
+            'name' => json_encode($newData['name'], JSON_UNESCAPED_SLASHES),
+            'description' => json_encode($newData['description'], JSON_UNESCAPED_SLASHES),
+            'age_representation' => $newData['age_representation'],
+        ]);
+    }
+
+    // --- Deletion and Reference Check Tests ---
+
+    public function test_admin_can_delete_an_unreferenced_age_rating(): void
+    {
+        $ageRating = AgeRating::factory()->create();
+
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(EditAgeRating::class, ['record' => $ageRating->id]);
+        $livewire->callAction(DeleteAction::class);
+        $livewire->assertSuccessful();
+
+        $this->assertModelMissing($ageRating);
+    }
+
+    public function test_delete_action_is_hidden_for_referenced_age_rating(): void
+    {
+        $ageRating = AgeRating::factory()->create();
+        // Create a story and attach the age rating, making it 'referenced'
+        Story::factory()->hasAttached($ageRating, [], 'ageRatings')->create();
+
+        // Check on the List page (Table Action)
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(ListAgeRatings::class);
+        // Assert that the delete action is hidden for the specific record
+        $livewire->assertTableActionHidden('delete', $ageRating);
+
+        // Check on the Edit page (Header Action)
+        $livewire = Livewire::test(EditAgeRating::class, ['record' => $ageRating->id]);
+        $livewire->assertActionHidden('delete');
+    }
+
+    public function test_admin_can_bulk_delete_unreferenced_age_ratings(): void
+    {
+        $ageRatings = AgeRating::factory(3)->create();
+
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(ListAgeRatings::class);
+        $livewire->callTableBulkAction(DeleteBulkAction::class, $ageRatings);
+
+        foreach ($ageRatings as $ageRating) {
+            $this->assertModelMissing($ageRating);
+        }
+    }
+
+    public function test_admin_bulk_deletion_protects_referenced_age_ratings(): void
+    {
+        // One referenced, two unreferenced
+        $referencedAgeRating = AgeRating::factory()->create();
+        $unreferencedAgeRatings = AgeRating::factory(2)->create();
+        Story::factory()->hasAttached($referencedAgeRating, [], 'ageRatings')->create();
+
+        $allAgeRatings = collect([$referencedAgeRating])->merge($unreferencedAgeRatings);
+
+        $this->actingAs($this->adminUser);
+        $livewire = Livewire::test(ListAgeRatings::class);
+        // Call bulk action with all three age ratings
+        $livewire->callTableBulkAction('delete', $allAgeRatings->pluck('id')->toArray());
+
+        // Assert that the referenced age rating is protected and still exists
+        $this->assertModelExists($referencedAgeRating);
+
+        // Assert that the unreferenced age ratings were successfully deleted
+        foreach ($unreferencedAgeRatings as $ageRating) {
+            $this->assertDatabaseMissing('age_ratings', ['id' => $ageRating->id]);
+        }
+    }
+
+    public function test_assigning_age_ratings_to_story_updates_effective_age_rating(): void
+    {
+        /** @var Story */
+        $story = Story::factory()->create();
+        $ageRating1 = AgeRating::factory()->create(['age_representation' => 10]);
+        $ageRating2 = AgeRating::factory()->create(['age_representation' => 15]);
+
+        $this->actingAs($this->adminUser);
+
+        // Test attaching age ratings
+        $livewire = Livewire::test(\App\Filament\Resources\StoryResource\Pages\EditStory::class, ['record' => $story->id]);
+        $livewire->fillForm(['ageRatings' => [$ageRating1->id, $ageRating2->id]]);
+        $livewire->call('save');
+        $livewire->assertHasNoFormErrors();
+
+        $story = $story->refresh();
+        $this->assertEquals(15, $story->age_rating_effective_value);
+
+        // Test detaching an age rating
+        $livewire = Livewire::test(\App\Filament\Resources\StoryResource\Pages\EditStory::class, ['record' => $story->id]);
+        $livewire->fillForm(['ageRatings' => [$ageRating1->id]]);
+        $livewire->call('save');
+        $livewire->assertHasNoFormErrors();
+
+        $story->refresh();
+        $this->assertEquals(10, $story->age_rating_effective_value);
+
+        // Test detaching all age ratings
+        $livewire = Livewire::test(\App\Filament\Resources\StoryResource\Pages\EditStory::class, ['record' => $story->id]);
+        $livewire->fillForm(['ageRatings' => []]);
+        $livewire->call('save');
+        $livewire->assertHasNoFormErrors();
+
+        $story->refresh();
+        $this->assertNull($story->age_rating_effective_value);
+    }
+}

--- a/tests/Feature/Http/Middleware/RedirectRestrictedContentTest.php
+++ b/tests/Feature/Http/Middleware/RedirectRestrictedContentTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Http\Middleware;
+
+use App\Enums\Story\Status;
+use App\Models\AgeRating;
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class RedirectRestrictedContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('age_rating.guest_limit_years', 16);
+    }
+
+    public function test_guest_can_access_story_rated_below_limit(): void
+    {
+        $ageRating15 = AgeRating::factory()->create(['age_representation' => 15]);
+        $story = Story::factory()->create(['status' => Status::Publish]);
+        $story->ageRatings()->attach($ageRating15);
+        $story->save();
+
+        $response = $this->get(route('stories.show', $story));
+
+        $response->assertOk();
+    }
+
+    public function test_guest_is_redirected_from_story_rated_at_or_above_limit(): void
+    {
+        $ageRating16 = AgeRating::factory()->create(['age_representation' => 16]);
+        $ageRating18 = AgeRating::factory()->create(['age_representation' => 18]);
+
+        $storyAtLimit = Story::factory()->create(['status' => Status::Publish]);
+        $storyAtLimit->ageRatings()->attach($ageRating16);
+        $storyAtLimit->save();
+
+        $storyAboveLimit = Story::factory()->create(['status' => Status::Publish]);
+        $storyAboveLimit->ageRatings()->attach($ageRating18);
+        $storyAboveLimit->save();
+
+        $responseAtLimit = $this->get(route('stories.show', $storyAtLimit));
+        $responseAboveLimit = $this->get(route('stories.show', $storyAboveLimit));
+
+        $responseAtLimit->assertRedirect(route('login', ['next' => route('stories.show', $storyAtLimit)]));
+        $responseAboveLimit->assertRedirect(route('login', ['next' => route('stories.show', $storyAboveLimit)]));
+    }
+
+    public function test_guest_is_redirected_from_unrated_story(): void
+    {
+        $story = Story::factory()->create(['status' => Status::Publish]);
+        $story->save();
+
+        $response = $this->get(route('stories.show', $story));
+
+        $response->assertRedirect(route('login', ['next' => route('stories.show', $story)]));
+    }
+
+    public function test_authenticated_user_can_access_story_rated_above_limit(): void
+    {
+        $user = User::factory()->create();
+        $ageRating18 = AgeRating::factory()->create(['age_representation' => 18]);
+        $story = Story::factory()->create(['status' => Status::Publish]);
+        $story->ageRatings()->attach($ageRating18);
+        $story->save();
+
+        $response = $this->actingAs($user)->get(route('stories.show', $story));
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/Http/Responses/LoginResponseTest.php
+++ b/tests/Feature/Http/Responses/LoginResponseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Http\Responses;
+
+use App\Http\Responses\LoginResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class LoginResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('app.url', 'http://localhost:8000');
+        Config::set('fortify.home', '/dashboard');
+    }
+
+    public function test_redirects_to_valid_next_url_on_same_host(): void
+    {
+        $request = Request::create('/login', 'POST', ['next' => 'http://localhost/profile']);
+        $response = (new LoginResponse)->toResponse($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('http://localhost/profile', $response->headers->get('Location'));
+    }
+
+    public function test_ignores_external_next_url_and_redirects_to_default(): void
+    {
+        $request = Request::create('/login', 'POST', ['next' => 'http://external.com/malicious']);
+        $response = (new LoginResponse)->toResponse($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('http://localhost:8000/dashboard', $response->headers->get('Location'));
+    }
+
+    public function test_redirects_to_default_when_next_url_is_empty(): void
+    {
+        $request = Request::create('/login', 'POST', ['next' => '']);
+        $response = (new LoginResponse)->toResponse($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('http://localhost:8000/dashboard', $response->headers->get('Location'));
+    }
+
+    public function test_redirects_to_default_when_next_url_is_malformed(): void
+    {
+        $request = Request::create('/login', 'POST', ['next' => 'http:///malformed']);
+        $response = (new LoginResponse)->toResponse($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('http://localhost:8000/dashboard', $response->headers->get('Location'));
+    }
+
+    public function test_redirects_to_default_when_next_url_has_different_subdomain(): void
+    {
+        $request = Request::create('/login', 'POST', ['next' => 'http://sub.localhost/profile']);
+        $response = (new LoginResponse)->toResponse($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('http://localhost:8000/dashboard', $response->headers->get('Location'));
+    }
+}

--- a/tests/Unit/Models/AgeRatingTest.php
+++ b/tests/Unit/Models/AgeRatingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\AgeRating;
+use App\Models\Story;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AgeRatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_age_rating_can_be_associated_with_multiple_stories(): void
+    {
+        $ageRating = AgeRating::factory()->create();
+        $stories = Story::factory()->count(3)->create();
+
+        $ageRating->stories()->attach($stories->pluck('id'));
+
+        $this->assertCount(3, $ageRating->stories);
+        $firstStory = $stories->first();
+        $this->assertNotNull($firstStory);
+        $this->assertTrue($ageRating->stories->contains($firstStory));
+    }
+
+    public function test_is_referenced_returns_true_if_associated_with_stories(): void
+    {
+        $ageRating = AgeRating::factory()->create();
+        $story = Story::factory()->create();
+        $ageRating->stories()->attach($story);
+
+        $this->assertTrue($ageRating->isReferenced());
+    }
+
+    public function test_is_referenced_returns_false_if_not_associated_with_stories(): void
+    {
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertFalse($ageRating->isReferenced());
+    }
+}

--- a/tests/Unit/Models/StoryTest.php
+++ b/tests/Unit/Models/StoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use App\Models\AgeRating;
 use App\Models\Genre;
 use App\Models\Story;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -35,5 +36,34 @@ class StoryTest extends TestCase
         $this->assertEquals('story_id', $relation->getForeignPivotKeyName());
         $this->assertEquals('genre_id', $relation->getRelatedPivotKeyName());
         $this->assertEquals(Genre::class, $relation->getRelated()->getMorphClass());
+    }
+
+    public function test_a_story_can_have_multiple_age_ratings(): void
+    {
+        $story = Story::factory()->create();
+        $ageRatings = AgeRating::factory()->count(3)->create();
+
+        $story->ageRatings()->attach($ageRatings->pluck('id'));
+
+        $this->assertCount(3, $story->ageRatings);
+        $firstAgeRating = $ageRatings->first();
+        $this->assertNotNull($firstAgeRating);
+        $this->assertTrue($story->ageRatings->contains($firstAgeRating));
+    }
+
+    public function test_age_ratings_can_be_detached_from_a_story(): void
+    {
+        $story = Story::factory()->create();
+        $ageRatings = AgeRating::factory()->count(3)->create();
+
+        $story->ageRatings()->attach($ageRatings->pluck('id'));
+        $this->assertCount(3, $story->ageRatings);
+
+        $firstAgeRating = $ageRatings->first();
+        $this->assertNotNull($firstAgeRating);
+        $story->ageRatings()->detach($firstAgeRating);
+        $story->load('ageRatings'); // Reload the relationship
+
+        $this->assertCount(2, $story->ageRatings);
     }
 }

--- a/tests/Unit/Observers/StoryObserverTest.php
+++ b/tests/Unit/Observers/StoryObserverTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\Observers;
+
+use App\Models\AgeRating;
+use App\Models\Story;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoryObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_effective_age_rating_is_null_when_no_age_ratings_are_associated(): void
+    {
+        $story = Story::factory()->create();
+
+        $this->assertNull($story->age_rating_effective_value);
+    }
+
+    public function test_effective_age_rating_is_set_to_the_highest_age_representation(): void
+    {
+        $story = Story::factory()->create();
+        $ageRating1 = AgeRating::factory()->create(['age_representation' => 10]);
+        $ageRating2 = AgeRating::factory()->create(['age_representation' => 18]);
+        $ageRating3 = AgeRating::factory()->create(['age_representation' => 13]);
+
+        $story->ageRatings()->attach([$ageRating1->id, $ageRating2->id, $ageRating3->id]);
+        $story->save(); // Trigger the observer
+
+        $this->assertEquals(18, $story->age_rating_effective_value);
+    }
+
+    public function test_effective_age_rating_updates_when_age_ratings_are_added(): void
+    {
+        /** @var Story */
+        $story = Story::factory()->create();
+        $ageRating1 = AgeRating::factory()->create(['age_representation' => 10]);
+
+        $story->ageRatings()->attach($ageRating1->id);
+        $story->save();
+
+        $this->assertEquals(10, $story->age_rating_effective_value);
+
+        $ageRating2 = AgeRating::factory()->create(['age_representation' => 15]);
+        $story->ageRatings()->attach($ageRating2->id);
+        $story->load('ageRatings'); // Explicitly reload the relationship
+        $story->save();
+
+        $this->assertEquals(15, $story->age_rating_effective_value);
+    }
+
+    public function test_effective_age_rating_updates_when_age_ratings_are_removed(): void
+    {
+        $story = Story::factory()->create();
+        $ageRating1 = AgeRating::factory()->create(['age_representation' => 10]);
+        $ageRating2 = AgeRating::factory()->create(['age_representation' => 15]);
+
+        $story->ageRatings()->attach([$ageRating1->id, $ageRating2->id]);
+        $story->save();
+
+        $this->assertEquals(15, $story->age_rating_effective_value);
+
+        $story->ageRatings()->detach($ageRating2->id);
+        $story->load('ageRatings'); // Explicitly reload the relationship
+        $story->save();
+
+        $this->assertEquals(10, $story->age_rating_effective_value);
+    }
+
+    public function test_effective_age_rating_becomes_null_when_all_age_ratings_are_removed(): void
+    {
+        $story = Story::factory()->create();
+        $ageRating = AgeRating::factory()->create(['age_representation' => 10]);
+
+        $story->ageRatings()->attach($ageRating->id);
+        $story->save();
+
+        $this->assertEquals(10, $story->age_rating_effective_value);
+
+        $story->ageRatings()->detach($ageRating->id);
+        $story->load('ageRatings'); // Explicitly reload the relationship
+        $story->save();
+
+        $this->assertNull($story->age_rating_effective_value);
+    }
+
+    public function test_effective_age_rating_updates_when_age_rating_representation_changes(): void
+    {
+        $story = Story::factory()->create();
+        $ageRating = AgeRating::factory()->create(['age_representation' => 10]);
+
+        $story->ageRatings()->attach($ageRating->id);
+        $story->save();
+
+        $this->assertEquals(10, $story->age_rating_effective_value);
+
+        $ageRating->age_representation = 20;
+        $ageRating->save();
+
+        // Re-attach to trigger observer on story, or reload story and save
+        // For simplicity, we'll just re-load and save the story to trigger the observer
+        $story->load('ageRatings');
+        $story->save();
+
+        $this->assertEquals(20, $story->age_rating_effective_value);
+    }
+}

--- a/tests/Unit/Observers/StoryObserverTest.php
+++ b/tests/Unit/Observers/StoryObserverTest.php
@@ -44,7 +44,6 @@ class StoryObserverTest extends TestCase
 
         $ageRating2 = AgeRating::factory()->create(['age_representation' => 15]);
         $story->ageRatings()->attach($ageRating2->id);
-        $story->load('ageRatings'); // Explicitly reload the relationship
         $story->save();
 
         $this->assertEquals(15, $story->age_rating_effective_value);
@@ -62,7 +61,6 @@ class StoryObserverTest extends TestCase
         $this->assertEquals(15, $story->age_rating_effective_value);
 
         $story->ageRatings()->detach($ageRating2->id);
-        $story->load('ageRatings'); // Explicitly reload the relationship
         $story->save();
 
         $this->assertEquals(10, $story->age_rating_effective_value);
@@ -79,7 +77,6 @@ class StoryObserverTest extends TestCase
         $this->assertEquals(10, $story->age_rating_effective_value);
 
         $story->ageRatings()->detach($ageRating->id);
-        $story->load('ageRatings'); // Explicitly reload the relationship
         $story->save();
 
         $this->assertNull($story->age_rating_effective_value);
@@ -99,8 +96,7 @@ class StoryObserverTest extends TestCase
         $ageRating->save();
 
         // Re-attach to trigger observer on story, or reload story and save
-        // For simplicity, we'll just re-load and save the story to trigger the observer
-        $story->load('ageRatings');
+        // For simplicity, we'll just save the story to trigger the observer
         $story->save();
 
         $this->assertEquals(20, $story->age_rating_effective_value);

--- a/tests/Unit/Policies/AgeRatingPolicyTest.php
+++ b/tests/Unit/Policies/AgeRatingPolicyTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\AgeRating;
+use App\Models\Permission;
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AgeRatingPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure permissions exist for testing
+        Permission::findOrCreate('view_any_age::rating');
+        Permission::findOrCreate('view_age::rating');
+        Permission::findOrCreate('create_age::rating');
+        Permission::findOrCreate('update_age::rating');
+        Permission::findOrCreate('delete_age::rating');
+    }
+
+    public function test_authorized_user_can_view_any_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('view_any_age::rating');
+
+        $this->assertTrue($user->can('viewAny', AgeRating::class));
+    }
+
+    public function test_unauthorized_user_cannot_view_any_age_rating(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->can('viewAny', AgeRating::class));
+    }
+
+    public function test_authorized_user_can_view_a_specific_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('view_age::rating');
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertTrue($user->can('view', $ageRating));
+    }
+
+    public function test_unauthorized_user_cannot_view_a_specific_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertFalse($user->can('view', $ageRating));
+    }
+
+    public function test_authorized_user_can_create_age_ratings(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('create_age::rating');
+
+        $this->assertTrue($user->can('create', AgeRating::class));
+    }
+
+    public function test_unauthorized_user_cannot_create_age_ratings(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->can('create', AgeRating::class));
+    }
+
+    public function test_authorized_user_can_update_an_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('update_age::rating');
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertTrue($user->can('update', $ageRating));
+    }
+
+    public function test_unauthorized_user_cannot_update_an_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertFalse($user->can('update', $ageRating));
+    }
+
+    public function test_authorized_user_can_delete_an_unreferenced_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('delete_age::rating');
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertFalse($ageRating->isReferenced());
+        $this->assertTrue($user->can('delete', $ageRating));
+    }
+
+    public function test_authorized_user_cannot_delete_a_referenced_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('delete_age::rating');
+        $ageRating = AgeRating::factory()->create();
+        $story = Story::factory()->create();
+        $ageRating->stories()->attach($story);
+
+        $this->assertTrue($ageRating->isReferenced());
+        $this->assertFalse($user->can('delete', $ageRating));
+    }
+
+    public function test_unauthorized_user_cannot_delete_any_age_rating(): void
+    {
+        $user = User::factory()->create();
+        $ageRating = AgeRating::factory()->create();
+
+        $this->assertFalse($user->can('delete', $ageRating));
+    }
+}

--- a/tests/Unit/Policies/AgeRatingPolicyTest.php
+++ b/tests/Unit/Policies/AgeRatingPolicyTest.php
@@ -6,6 +6,7 @@ use App\Models\AgeRating;
 use App\Models\Permission;
 use App\Models\Story;
 use App\Models\User;
+use App\Policies\AgeRatingPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -117,5 +118,48 @@ class AgeRatingPolicyTest extends TestCase
         $ageRating = AgeRating::factory()->create();
 
         $this->assertFalse($user->can('delete', $ageRating));
+    }
+
+    public function test_delete_is_denied_for_referenced_age_rating(): void
+    {
+        // 1. Arrange
+        $policy = new AgeRatingPolicy;
+        $user = User::factory()->create();
+        $user->givePermissionTo('delete_age::rating'); // Grant base permission
+
+        $ageRating = AgeRating::factory()->create();
+        $story = Story::factory()->create();
+        $story->ageRatings()->attach($ageRating); // Make the rating "referenced"
+
+        // 2. Act & Assert
+        // Directly call the policy method and assert it denies the action.
+        $this->assertFalse($policy->delete($user, $ageRating));
+    }
+
+    public function test_delete_is_allowed_for_unreferenced_age_rating(): void
+    {
+        // 1. Arrange
+        $policy = new AgeRatingPolicy;
+        $user = User::factory()->create();
+        $user->givePermissionTo('delete_age::rating'); // Grant base permission
+
+        $ageRating = AgeRating::factory()->create(); // This rating is not attached to any story
+
+        // 2. Act & Assert
+        // Assert the policy allows the action for an unreferenced rating.
+        $this->assertTrue($policy->delete($user, $ageRating));
+    }
+
+    public function test_delete_is_denied_if_user_lacks_permission(): void
+    {
+        // 1. Arrange
+        $policy = new AgeRatingPolicy;
+        $user = User::factory()->create(); // User does NOT have the 'delete_age::rating' permission
+
+        $ageRating = AgeRating::factory()->create(); // Unreferenced rating
+
+        // 2. Act & Assert
+        // Assert the policy denies the action due to missing permissions.
+        $this->assertFalse($policy->delete($user, $ageRating));
     }
 }

--- a/tests/Unit/Scopes/GuestStoryFilterScopeTest.php
+++ b/tests/Unit/Scopes/GuestStoryFilterScopeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit\Scopes;
+
+use App\Models\AgeRating;
+use App\Models\Story;
+use App\Scopes\GuestStoryFilterScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class GuestStoryFilterScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Ensure the age_rating config is set for testing
+        Config::set('age_rating.guest_limit_years', 16);
+    }
+
+    public function test_filters_stories_for_guest_users(): void
+    {
+        Auth::shouldReceive('guest')->andReturn(true);
+
+        // Create stories with different age ratings
+        // Create AgeRating instances
+        $ageRating15 = \App\Models\AgeRating::factory()->create(['age_representation' => 15]);
+        $ageRating16 = \App\Models\AgeRating::factory()->create(['age_representation' => 16]);
+        $ageRating18 = \App\Models\AgeRating::factory()->create(['age_representation' => 18]);
+
+        // Create stories and attach age ratings
+        $story15 = Story::factory()->create();
+        $story15->ageRatings()->attach($ageRating15);
+        $story15->save(); // Trigger observer to calculate age_rating_effective_value
+
+        $story16 = Story::factory()->create();
+        $story16->ageRatings()->attach($ageRating16);
+        $story16->save(); // Trigger observer
+
+        $story18 = Story::factory()->create();
+        $story18->ageRatings()->attach($ageRating18);
+        $story18->save(); // Trigger observer
+
+        // Story with no age rating (should have null effective value)
+        $storyNull = Story::factory()->create();
+        $storyNull->save(); // Trigger observer (will set age_rating_effective_value to null)
+
+        $filteredStories = Story::withoutGlobalScope(GuestStoryFilterScope::class)
+            ->withGlobalScope('guest_filter', new GuestStoryFilterScope)
+            ->get();
+
+        $this->assertCount(1, $filteredStories);
+        $this->assertTrue($filteredStories->contains($story15));
+    }
+
+    public function test_does_not_filter_stories_for_authenticated_users(): void
+    {
+        Auth::shouldReceive('guest')->andReturn(false);
+
+        // Create AgeRating instances
+        $ageRating15 = AgeRating::factory()->create(['age_representation' => 15]);
+        $ageRating16 = AgeRating::factory()->create(['age_representation' => 16]);
+        $ageRating18 = AgeRating::factory()->create(['age_representation' => 18]);
+
+        // Create stories and attach age ratings
+        $story15 = Story::factory()->create();
+        $story15->ageRatings()->attach($ageRating15);
+        $story15->save();
+
+        $story16 = Story::factory()->create();
+        $story16->ageRatings()->attach($ageRating16);
+        $story16->save();
+
+        $story18 = Story::factory()->create();
+        $story18->ageRatings()->attach($ageRating18);
+        $story18->save();
+
+        // Story with no age rating
+        $storyNull = Story::factory()->create();
+        $storyNull->save();
+
+        $filteredStories = Story::withoutGlobalScope(GuestStoryFilterScope::class)
+            ->withGlobalScope('guest_filter', new GuestStoryFilterScope)
+            ->get();
+
+        $this->assertCount(4, $filteredStories); // All stories should be returned
+        $this->assertTrue($filteredStories->contains($story15));
+        $this->assertTrue($filteredStories->contains($story16));
+        $this->assertTrue($filteredStories->contains($story18));
+        $this->assertTrue($filteredStories->contains($storyNull));
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive age rating system to classify stories and restrict content for unauthenticated (guest) users. It includes database schema updates, new models, business logic for calculating an effective rating, a full management interface in the Filament admin panel, and middleware to enforce access restrictions.

### Key Features Implemented:

- **Database Schema & Models:**

  - Introduced an `age_ratings` table with translatable JSON fields for name/description.
  - Added an `age_rating_story` pivot table to establish a many-to-many relationship.
  - A new `age_rating_effective_value` column on the `stories` table stores the highest applicable age rating.
  - Created the `AgeRating` Eloquent model with relationships, a factory, and translation support via `spatie/laravel-translatable`.

- **Effective Age Rating Calculation:**

  - An `StoryObserver` automatically calculates and stores the maximum age rating from all associated ratings whenever a story is saved, ensuring the most restrictive rating is always enforced.

- **Filament Admin Panel Integration:**

  - A new `AgeRatingResource` provides full CRUD functionality for managing age ratings, complete with localization and authorization policies.
  - The `StoryResource` form has been updated to allow administrators to assign multiple age ratings to a story.
  - A new filter was added to the `StoryResource` table to easily find stories that are "Awaiting Rating" or "Rated".

- **Guest Content Restriction & Redirection:**

  - A configurable age limit (`config/age_rating.php`) is used to filter content for guest users.
  - A `GuestStoryFilterScope` is applied to story queries for guests, hiding content that exceeds the configured age limit from lists and tables.
  - New `RedirectRestrictedContent` middleware protects direct access to restricted story pages. Unauthenticated users are redirected to the login page.
  - The Fortify `LoginResponse` has been customized to redirect users back to their intended restricted page after a successful login.

- **Authorization & Safety:**

  - An `AgeRatingPolicy` is implemented to control user permissions for viewing, creating, updating, and deleting age ratings.
  - The policy prevents the deletion of an age rating if it is currently assigned to one or more stories.

- **Comprehensive Testing:**

  - The feature is supported by an extensive suite of tests, including:
    - **Unit tests** for models, observers, policies, and scopes.
    - **Feature tests** for the Filament resource, middleware, and custom login response.
    - A full **End-to-End (E2E) test** that validates the entire workflow from creating a rating and assigning it to a story to verifying the guest redirection logic.