### PR TITLE
feat: introduce guest role and permissions

### DIFF
--- a/app/Constants/Permissions.php
+++ b/app/Constants/Permissions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Constants;
+
+class Permissions
+{
+    public const ACT_AS_GUEST = 'act_as_guest';
+}

--- a/app/Constants/Roles.php
+++ b/app/Constants/Roles.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Constants;
+
+class Roles
+{
+    public const GUEST = 'Guest';
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             StoryCommentSeeder::class,
             StoryCommentVoteSeeder::class,
+            GuestRoleAndPermissionSeeder::class,
         ]);
     }
 }

--- a/database/seeders/GuestRoleAndPermissionSeeder.php
+++ b/database/seeders/GuestRoleAndPermissionSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Permission;
 use App\Models\Role;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class GuestRoleAndPermissionSeeder extends Seeder
 {
@@ -13,13 +14,15 @@ class GuestRoleAndPermissionSeeder extends Seeder
      */
     public function run(): void
     {
-        // Create the 'act_as_guest' permission
-        $permission = Permission::firstOrCreate(['name' => 'act_as_guest', 'guard_name' => 'web']);
+        DB::transaction(function () {
+            // Create the 'act_as_guest' permission
+            $permission = Permission::firstOrCreate(['name' => 'act_as_guest', 'guard_name' => 'web']);
 
-        // Create the 'Guest' role
-        $role = Role::firstOrCreate(['name' => 'Guest', 'guard_name' => 'web']);
+            // Create the 'Guest' role
+            $role = Role::firstOrCreate(['name' => 'Guest', 'guard_name' => 'web']);
 
-        // Assign the 'act_as_guest' permission to the 'Guest' role
-        $role->givePermissionTo($permission);
+            // Assign the 'act_as_guest' permission to the 'Guest' role
+            $role->givePermissionTo($permission);
+        });
     }
 }

--- a/database/seeders/GuestRoleAndPermissionSeeder.php
+++ b/database/seeders/GuestRoleAndPermissionSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class GuestRoleAndPermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Create the 'act_as_guest' permission
+        Permission::firstOrCreate(['name' => 'act_as_guest', 'guard_name' => 'web']);
+
+        // Create the 'Guest' role
+        $role = Role::firstOrCreate(['name' => 'Guest', 'guard_name' => 'web']);
+
+        // Assign the 'act_as_guest' permission to the 'Guest' role
+        $role->givePermissionTo('act_as_guest');
+    }
+}

--- a/database/seeders/GuestRoleAndPermissionSeeder.php
+++ b/database/seeders/GuestRoleAndPermissionSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\Permission;
+use App\Models\Role;
 use Illuminate\Database\Seeder;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 class GuestRoleAndPermissionSeeder extends Seeder
 {
@@ -14,12 +14,12 @@ class GuestRoleAndPermissionSeeder extends Seeder
     public function run(): void
     {
         // Create the 'act_as_guest' permission
-        Permission::firstOrCreate(['name' => 'act_as_guest', 'guard_name' => 'web']);
+        $permission = Permission::firstOrCreate(['name' => 'act_as_guest', 'guard_name' => 'web']);
 
         // Create the 'Guest' role
         $role = Role::firstOrCreate(['name' => 'Guest', 'guard_name' => 'web']);
 
         // Assign the 'act_as_guest' permission to the 'Guest' role
-        $role->givePermissionTo('act_as_guest');
+        $role->givePermissionTo($permission);
     }
 }

--- a/database/seeders/GuestRoleAndPermissionSeeder.php
+++ b/database/seeders/GuestRoleAndPermissionSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Constants\Permissions;
+use App\Constants\Roles;
 use App\Models\Permission;
 use App\Models\Role;
 use Illuminate\Database\Seeder;
@@ -15,13 +17,13 @@ class GuestRoleAndPermissionSeeder extends Seeder
     public function run(): void
     {
         DB::transaction(function () {
-            // Create the 'act_as_guest' permission
-            $permission = Permission::firstOrCreate(['name' => 'act_as_guest', 'guard_name' => 'web']);
+            // Create the ACT_AS_GUEST permission
+            $permission = Permission::firstOrCreate(['name' => Permissions::ACT_AS_GUEST, 'guard_name' => 'web']);
 
-            // Create the 'Guest' role
-            $role = Role::firstOrCreate(['name' => 'Guest', 'guard_name' => 'web']);
+            // Create the GUEST role
+            $role = Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
 
-            // Assign the 'act_as_guest' permission to the 'Guest' role
+            // Assign the ACT_AS_GUEST permission to the GUEST role
             $role->givePermissionTo($permission);
         });
     }

--- a/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
@@ -30,4 +30,17 @@ class GuestRoleAndPermissionSeederTest extends TestCase
         // Assert that the 'Guest' role has the 'act_as_guest' permission
         $this->assertTrue($guestRole->hasPermissionTo(Permissions::ACT_AS_GUEST), 'Guest role should have act_as_guest permission.');
     }
+
+    public function test_seeder_is_idempotent(): void
+    {
+        // Run the seeder twice
+        $this->seed(GuestRoleAndPermissionSeeder::class);
+        $this->seed(GuestRoleAndPermissionSeeder::class);
+
+        // Assert that only one 'Guest' role exists
+        $this->assertSame(1, Role::where('name', Roles::GUEST)->count(), 'There should be exactly one Guest role.');
+
+        // Assert that only one 'act_as_guest' permission exists
+        $this->assertSame(1, Permission::where('name', Permissions::ACT_AS_GUEST)->count(), 'There should be exactly one act_as_guest permission.');
+    }
 }

--- a/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Database\Seeders\GuestRoleAndPermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuestRoleAndPermissionSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_role_and_permission_are_created_and_linked(): void
+    {
+        // Run the seeder
+        $this->seed(GuestRoleAndPermissionSeeder::class);
+
+        // Assert that the 'Guest' role exists
+        $guestRole = Role::where('name', 'Guest')->first();
+        $this->assertNotNull($guestRole, 'Guest role should exist.');
+
+        // Assert that the 'act_as_guest' permission exists
+        $actAsGuestPermission = Permission::where('name', 'act_as_guest')->first();
+        $this->assertNotNull($actAsGuestPermission, 'act_as_guest permission should exist.');
+
+        // Assert that the 'Guest' role has the 'act_as_guest' permission
+        $this->assertTrue($guestRole->hasPermissionTo('act_as_guest'), 'Guest role should have act_as_guest permission.');
+    }
+}

--- a/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Seeders;
 
+use App\Constants\Permissions;
+use App\Constants\Roles;
 use App\Models\Permission;
 use App\Models\Role;
 use Database\Seeders\GuestRoleAndPermissionSeeder;
@@ -18,14 +20,14 @@ class GuestRoleAndPermissionSeederTest extends TestCase
         $this->seed(GuestRoleAndPermissionSeeder::class);
 
         // Assert that the 'Guest' role exists
-        $guestRole = Role::where('name', 'Guest')->first();
+        $guestRole = Role::where('name', Roles::GUEST)->first();
         $this->assertNotNull($guestRole, 'Guest role should exist.');
 
         // Assert that the 'act_as_guest' permission exists
-        $actAsGuestPermission = Permission::where('name', 'act_as_guest')->first();
+        $actAsGuestPermission = Permission::where('name', Permissions::ACT_AS_GUEST)->first();
         $this->assertNotNull($actAsGuestPermission, 'act_as_guest permission should exist.');
 
         // Assert that the 'Guest' role has the 'act_as_guest' permission
-        $this->assertTrue($guestRole->hasPermissionTo('act_as_guest'), 'Guest role should have act_as_guest permission.');
+        $this->assertTrue($guestRole->hasPermissionTo(Permissions::ACT_AS_GUEST), 'Guest role should have act_as_guest permission.');
     }
 }

--- a/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
@@ -20,15 +20,14 @@ class GuestRoleAndPermissionSeederTest extends TestCase
         $this->seed(GuestRoleAndPermissionSeeder::class);
 
         // Assert that the 'Guest' role exists
-        $guestRole = Role::where('name', Roles::GUEST)->first();
-        $this->assertNotNull($guestRole, 'Guest role should exist.');
+        $this->assertSame(1, Role::where('name', Roles::GUEST)->count(), 'Guest role should exist.');
 
         // Assert that the 'act_as_guest' permission exists
-        $actAsGuestPermission = Permission::where('name', Permissions::ACT_AS_GUEST)->first();
-        $this->assertNotNull($actAsGuestPermission, 'act_as_guest permission should exist.');
+        $this->assertSame(1, Permission::where('name', Permissions::ACT_AS_GUEST)->count(), 'act_as_guest permission should exist.');
 
         // Assert that the 'Guest' role has the 'act_as_guest' permission
-        $this->assertTrue($guestRole->hasPermissionTo(Permissions::ACT_AS_GUEST), 'Guest role should have act_as_guest permission.');
+        $guestRole = Role::where('name', Roles::GUEST)->first();
+        $this->assertTrue($guestRole?->hasPermissionTo(Permissions::ACT_AS_GUEST), 'Guest role should have act_as_guest permission.');
     }
 
     public function test_seeder_is_idempotent(): void


### PR DESCRIPTION
This pull request introduces a dedicated seeder to establish a 'Guest' role and an associated 'act_as_guest' permission. This provides a standardized way to grant temporary or limited access to guest users.

Key changes include:

- **Guest Seeder:** A new `GuestRoleAndPermissionSeeder` is created to handle the creation and assignment of the guest role and its permission.
- **Constants:** Introduces `Roles::GUEST` and `Permissions::ACT_AS_GUEST` constants to eliminate magic strings and improve code maintainability.
- **Atomicity:** The seeding logic is wrapped in a database transaction to ensure that the role and permission are created and linked together successfully, or not at all.
- **Comprehensive Testing:** Feature tests have been added to verify:
  - The seeder correctly creates the role and permission.
  - The seeder is idempotent, meaning it can be run multiple times without causing errors or creating duplicate entries.
  - Assertions are robust and explicit.