### PR TITLE
feat: add guest state to user factory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -60,15 +60,18 @@ class UserFactory extends Factory
      */
     public function guest(): static
     {
-        return $this->afterCreating(function (User $user) {
-            if (static::$guestRole === null) {
-                static::$guestRole = Role::where('name', Roles::GUEST)->first();
-            }
+        if (static::$guestRole === null) {
+            static::$guestRole = Role::where('name', Roles::GUEST)->first();
+        }
 
-            if (! static::$guestRole) {
-                throw new ModelNotFoundException('Guest role not found.');
-            }
-            $user->assignRole(static::$guestRole);
+        $guestRole = static::$guestRole;
+
+        if (! $guestRole) {
+            throw new ModelNotFoundException('Guest role not found.');
+        }
+
+        return $this->afterCreating(function (User $user) use ($guestRole) {
+            $user->assignRole($guestRole);
         });
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -6,6 +6,7 @@ use App\Constants\Roles;
 use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -56,9 +57,10 @@ class UserFactory extends Factory
     {
         return $this->afterCreating(function (User $user) {
             $guestRole = Role::where('name', Roles::GUEST)->first();
-            if ($guestRole) {
-                $user->assignRole($guestRole);
+            if (! $guestRole) {
+                throw new ModelNotFoundException('Guest role not found.');
             }
+            $user->assignRole($guestRole);
         });
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,9 @@
 
 namespace Database\Factories;
 
+use App\Constants\Roles;
+use App\Models\Role;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -44,5 +47,18 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    /**
+     * Indicate that the user should have the "Guest" role.
+     */
+    public function guest(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            $guestRole = Role::where('name', Roles::GUEST)->first();
+            if ($guestRole) {
+                $user->assignRole($guestRole);
+            }
+        });
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -67,7 +67,7 @@ class UserFactory extends Factory
         $guestRole = static::$guestRole;
 
         if (! $guestRole) {
-            throw new ModelNotFoundException('Guest role not found.');
+            throw new ModelNotFoundException('Guest role not found. Please ensure database seeders have been run.');
         }
 
         return $this->afterCreating(function (User $user) use ($guestRole) {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -21,6 +21,11 @@ class UserFactory extends Factory
     protected static ?string $password;
 
     /**
+     * The Guest role instance, cached after the first lookup.
+     */
+    protected static ?Role $guestRole = null;
+
+    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
@@ -56,11 +61,14 @@ class UserFactory extends Factory
     public function guest(): static
     {
         return $this->afterCreating(function (User $user) {
-            $guestRole = Role::where('name', Roles::GUEST)->first();
-            if (! $guestRole) {
+            if (static::$guestRole === null) {
+                static::$guestRole = Role::where('name', Roles::GUEST)->first();
+            }
+
+            if (! static::$guestRole) {
                 throw new ModelNotFoundException('Guest role not found.');
             }
-            $user->assignRole($guestRole);
+            $user->assignRole(static::$guestRole);
         });
     }
 }

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -40,6 +40,36 @@ class UserFactoryTest extends TestCase
         // Expect an exception when trying to create a user with the guest state
         $this->expectException(ModelNotFoundException::class);
 
-        $user = User::factory()->guest()->create();
+        User::factory()->guest()->create();
+    }
+
+    #[RunInSeparateProcess]
+    public function test_guest_role_query_is_cached_and_executed_only_once(): void
+    {
+        // Enable query logging
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+
+        // Ensure the 'Guest' role exists
+        Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
+
+        // Create multiple users with the guest state
+        User::factory()->guest()->create();
+        User::factory()->guest()->create();
+        User::factory()->guest()->create();
+
+        // Get all executed queries
+        $queries = \Illuminate\Support\Facades\DB::getQueryLog();
+
+        // Filter for queries related to fetching the 'Guest' role
+        $guestRoleQueries = array_filter($queries, function ($query) {
+            /** @var array<string, string> $query */
+            return str_contains($query['query'], 'select * from "roles" where "name" = ? limit 1');
+        });
+
+        // Assert that the guest role query was executed exactly once
+        $this->assertCount(1, $guestRoleQueries);
+
+        // Disable query logging
+        \Illuminate\Support\Facades\DB::disableQueryLog();
     }
 }

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Feature\Factories;
-
 use App\Constants\Roles;
 use App\Models\Role;
 use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Tests\TestCase;
 
 class UserFactoryTest extends TestCase
@@ -15,7 +15,7 @@ class UserFactoryTest extends TestCase
     public function test_a_user_created_with_guest_state_has_the_guest_role(): void
     {
         // Ensure the 'Guest' role exists in the database
-        Role::create(['name' => Roles::GUEST, 'guard_name' => 'web']);
+        Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
 
         $user = User::factory()->guest()->create();
 
@@ -25,22 +25,21 @@ class UserFactoryTest extends TestCase
     public function test_a_user_created_without_guest_state_does_not_have_the_guest_role(): void
     {
         // Ensure the 'Guest' role exists, but the user shouldn't get it
-        Role::create(['name' => Roles::GUEST, 'guard_name' => 'web']);
+        Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
 
         $user = User::factory()->create();
 
         $this->assertFalse($user->hasRole(Roles::GUEST));
     }
 
+    #[RunInSeparateProcess]
     public function test_guest_state_throws_exception_if_guest_role_does_not_exist(): void
     {
         // Do NOT create the 'Guest' role in the database
 
         // Expect an exception when trying to create a user with the guest state
-        // The current implementation fails silently, so this test will initially fail.
-        // This test is to guide the next step (002-03) to add explicit error handling.
-        $this->expectException(\Exception::class); // This will be updated to ModelNotFoundException later
+        $this->expectException(ModelNotFoundException::class);
 
-        User::factory()->guest()->create();
+        $user = User::factory()->guest()->create();
     }
 }

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Factories;
+
+use App\Constants\Roles;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserFactoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function a_user_created_with_guest_state_has_the_guest_role(): void
+    {
+        // Ensure the 'Guest' role exists in the database
+        Role::create(['name' => Roles::GUEST, 'guard_name' => 'web']);
+
+        $user = User::factory()->guest()->create();
+
+        $this->assertTrue($user->hasRole(Roles::GUEST));
+    }
+
+    /** @test */
+    public function a_user_created_without_guest_state_does_not_have_the_guest_role(): void
+    {
+        // Ensure the 'Guest' role exists, but the user shouldn't get it
+        Role::create(['name' => Roles::GUEST, 'guard_name' => 'web']);
+
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->hasRole(Roles::GUEST));
+    }
+
+    /** @test */
+    public function guest_state_throws_exception_if_guest_role_does_not_exist(): void
+    {
+        // Do NOT create the 'Guest' role in the database
+
+        // Expect an exception when trying to create a user with the guest state
+        // The current implementation fails silently, so this test will initially fail.
+        // This test is to guide the next step (002-03) to add explicit error handling.
+        $this->expectException(\Exception::class); // This will be updated to ModelNotFoundException later
+
+        User::factory()->guest()->create();
+    }
+}

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Feature\Factories;
+
 use App\Constants\Roles;
 use App\Models\Role;
 use App\Models\User;

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -12,8 +12,7 @@ class UserFactoryTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function a_user_created_with_guest_state_has_the_guest_role(): void
+    public function test_a_user_created_with_guest_state_has_the_guest_role(): void
     {
         // Ensure the 'Guest' role exists in the database
         Role::create(['name' => Roles::GUEST, 'guard_name' => 'web']);
@@ -23,8 +22,7 @@ class UserFactoryTest extends TestCase
         $this->assertTrue($user->hasRole(Roles::GUEST));
     }
 
-    /** @test */
-    public function a_user_created_without_guest_state_does_not_have_the_guest_role(): void
+    public function test_a_user_created_without_guest_state_does_not_have_the_guest_role(): void
     {
         // Ensure the 'Guest' role exists, but the user shouldn't get it
         Role::create(['name' => Roles::GUEST, 'guard_name' => 'web']);
@@ -34,8 +32,7 @@ class UserFactoryTest extends TestCase
         $this->assertFalse($user->hasRole(Roles::GUEST));
     }
 
-    /** @test */
-    public function guest_state_throws_exception_if_guest_role_does_not_exist(): void
+    public function test_guest_state_throws_exception_if_guest_role_does_not_exist(): void
     {
         // Do NOT create the 'Guest' role in the database
 


### PR DESCRIPTION
This pull request introduces a new `guest()` state to the `UserFactory`, providing a convenient way to create users with a "Guest" role. This change improves both functionality and robustness through enhanced error handling, performance optimizations, and comprehensive testing.

Key changes include:

- **Guest Factory State:** A `guest()` method is added to the `UserFactory` to assign the "Guest" role to a user upon creation.
- **Robust Error Handling:** The factory now throws a descriptive `ModelNotFoundException` if the "Guest" role is not found, preventing silent failures and guiding developers to run the necessary database seeders.
- **Performance Optimization:** The "Guest" role lookup is now cached within the factory. This avoids redundant database queries when creating multiple guest users in a single process, improving performance.
- **Comprehensive Testing:**
  - Feature tests have been added to validate the correct assignment of the "Guest" role.
  - Tests confirm that the appropriate exception is thrown when the role is missing.
  - A specific test ensures that the role lookup query is cached and executed only once.
- **Code Refinements:** Test method naming conventions have been updated to align with modern PHPUnit standards for better code quality and consistency.