### PR TITLE
feat: implement guest user filtering in UserResource

### DIFF
--- a/app/Constants/Permissions.php
+++ b/app/Constants/Permissions.php
@@ -4,5 +4,5 @@ namespace App\Constants;
 
 class Permissions
 {
-    public const ACT_AS_GUEST = 'act_as_guest';
+    public const ACT_AS_GUEST_USER = 'act_as_guest_user';
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -2,12 +2,21 @@
 
 namespace App\Policies;
 
+use App\Constants\Permissions;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class UserPolicy
 {
     use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function actAsGuest(User $user): bool
+    {
+        return $user->can(Permissions::ACT_AS_GUEST_USER);
+    }
 
     /**
      * Determine whether the user can view any models.

--- a/database/seeders/GuestRoleAndPermissionSeeder.php
+++ b/database/seeders/GuestRoleAndPermissionSeeder.php
@@ -17,13 +17,13 @@ class GuestRoleAndPermissionSeeder extends Seeder
     public function run(): void
     {
         DB::transaction(function () {
-            // Create the ACT_AS_GUEST permission
-            $permission = Permission::firstOrCreate(['name' => Permissions::ACT_AS_GUEST, 'guard_name' => 'web']);
+            // Create the ACT_AS_GUEST_USER permission
+            $permission = Permission::firstOrCreate(['name' => Permissions::ACT_AS_GUEST_USER, 'guard_name' => 'web']);
 
             // Create the GUEST role
             $role = Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
 
-            // Assign the ACT_AS_GUEST permission to the GUEST role
+            // Assign the ACT_AS_GUEST_USER permission to the GUEST role
             $role->givePermissionTo($permission);
         });
     }

--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -6,5 +6,8 @@ return [
     'resource' => [
         'email_verified_at' => 'Email verified at',
         'model_label' => 'User|Users',
+        'user_type_label' => 'User Type',
+        'guest_users_label' => 'Guest Users',
+        'regular_users_label' => 'Regular Users',
     ],
 ];

--- a/lang/id/user.php
+++ b/lang/id/user.php
@@ -6,5 +6,8 @@ return [
     'resource' => [
         'email_verified_at' => 'Email diverifikasi pada',
         'model_label' => 'Pengguna|Pengguna',
+        'user_type_label' => 'Tipe Pengguna',
+        'guest_users_label' => 'Pengguna Tamu',
+        'regular_users_label' => 'Pengguna Reguler',
     ],
 ];

--- a/tests/Feature/E2E/UserResourceFilterTest.php
+++ b/tests/Feature/E2E/UserResourceFilterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Filament\E2E;
+
+use App\Constants\Permissions;
+use App\Filament\Resources\UserResource;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class UserResourceFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $adminUser;
+
+    protected User $guestUser;
+
+    protected User $regularUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup Spatie Permissions and Users
+        $guestPermission = Permission::create(['name' => Permissions::ACT_AS_GUEST_USER]);
+
+        // Create an admin user with all permissions
+        $this->adminUser = User::factory()->create();
+        Config::set('auth.super_users', [$this->adminUser->email]);
+
+        // Create a guest user
+        $this->guestUser = User::factory()->create();
+        $this->guestUser->givePermissionTo($guestPermission);
+
+        // Create a regular user (without guest permission)
+        $this->regularUser = User::factory()->create();
+    }
+
+    public function test_can_filter_users_by_author_type(): void
+    {
+        $this->actingAs($this->adminUser);
+
+        // 1. Assert both users are visible initially
+        Livewire::test(UserResource\Pages\ListUsers::class)
+            ->assertCanSeeTableRecords([$this->guestUser, $this->regularUser]);
+
+        // 2. Apply 'Guest Users' filter and assert only guest user is visible
+        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
+        $livewire->filterTable('user_type', true);
+        $livewire->assertCanSeeTableRecords([$this->guestUser]);
+        $livewire->assertCanNotSeeTableRecords([$this->regularUser]);
+
+        // 3. Apply 'Regular Users' filter and assert only regular user is visible
+        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
+        $livewire->filterTable('user_type', false);
+        $livewire->assertCanSeeTableRecords([$this->regularUser]);
+        $livewire->assertCanNotSeeTableRecords([$this->guestUser]);
+
+        // 4. Clear the filter and assert both users are visible
+        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
+        $livewire->filterTable('user_type', null); // Clear filter
+        $livewire->assertCanSeeTableRecords([$this->guestUser, $this->regularUser]);
+    }
+}

--- a/tests/Feature/E2E/UserResourceFilterTest.php
+++ b/tests/Feature/E2E/UserResourceFilterTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Filament\E2E;
 
 use App\Constants\Permissions;
+use App\Constants\Roles;
 use App\Filament\Resources\UserResource;
 use App\Models\Permission;
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
@@ -25,8 +27,10 @@ class UserResourceFilterTest extends TestCase
     {
         parent::setUp();
 
-        // Setup Spatie Permissions and Users
-        $guestPermission = Permission::create(['name' => Permissions::ACT_AS_GUEST_USER]);
+        // Setup Roles and Permissions
+        $permission = Permission::firstOrCreate(['name' => Permissions::ACT_AS_GUEST_USER, 'guard_name' => 'web']);
+        $role = Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
+        $role->givePermissionTo($permission);
 
         // Create an admin user with all permissions
         $this->adminUser = User::factory()->create();
@@ -34,9 +38,9 @@ class UserResourceFilterTest extends TestCase
 
         // Create a guest user
         $this->guestUser = User::factory()->create();
-        $this->guestUser->givePermissionTo($guestPermission);
+        $this->guestUser->assignRole($role);
 
-        // Create a regular user (without guest permission)
+        // Create a regular user (without guest role)
         $this->regularUser = User::factory()->create();
     }
 
@@ -44,24 +48,22 @@ class UserResourceFilterTest extends TestCase
     {
         $this->actingAs($this->adminUser);
 
+        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
+
         // 1. Assert both users are visible initially
-        Livewire::test(UserResource\Pages\ListUsers::class)
-            ->assertCanSeeTableRecords([$this->guestUser, $this->regularUser]);
+        $livewire->assertCanSeeTableRecords([$this->guestUser, $this->regularUser]);
 
         // 2. Apply 'Guest Users' filter and assert only guest user is visible
-        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
         $livewire->filterTable('user_type', true);
         $livewire->assertCanSeeTableRecords([$this->guestUser]);
         $livewire->assertCanNotSeeTableRecords([$this->regularUser]);
 
         // 3. Apply 'Regular Users' filter and assert only regular user is visible
-        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
         $livewire->filterTable('user_type', false);
         $livewire->assertCanSeeTableRecords([$this->regularUser]);
         $livewire->assertCanNotSeeTableRecords([$this->guestUser]);
 
         // 4. Clear the filter and assert both users are visible
-        $livewire = Livewire::test(UserResource\Pages\ListUsers::class);
         $livewire->filterTable('user_type', null); // Clear filter
         $livewire->assertCanSeeTableRecords([$this->guestUser, $this->regularUser]);
     }

--- a/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeders/GuestRoleAndPermissionSeederTest.php
@@ -23,11 +23,11 @@ class GuestRoleAndPermissionSeederTest extends TestCase
         $this->assertSame(1, Role::where('name', Roles::GUEST)->count(), 'Guest role should exist.');
 
         // Assert that the 'act_as_guest' permission exists
-        $this->assertSame(1, Permission::where('name', Permissions::ACT_AS_GUEST)->count(), 'act_as_guest permission should exist.');
+        $this->assertSame(1, Permission::where('name', Permissions::ACT_AS_GUEST_USER)->count(), 'act_as_guest permission should exist.');
 
         // Assert that the 'Guest' role has the 'act_as_guest' permission
         $guestRole = Role::where('name', Roles::GUEST)->first();
-        $this->assertTrue($guestRole?->hasPermissionTo(Permissions::ACT_AS_GUEST), 'Guest role should have act_as_guest permission.');
+        $this->assertTrue($guestRole?->hasPermissionTo(Permissions::ACT_AS_GUEST_USER), 'Guest role should have act_as_guest permission.');
     }
 
     public function test_seeder_is_idempotent(): void
@@ -40,6 +40,6 @@ class GuestRoleAndPermissionSeederTest extends TestCase
         $this->assertSame(1, Role::where('name', Roles::GUEST)->count(), 'There should be exactly one Guest role.');
 
         // Assert that only one 'act_as_guest' permission exists
-        $this->assertSame(1, Permission::where('name', Permissions::ACT_AS_GUEST)->count(), 'There should be exactly one act_as_guest permission.');
+        $this->assertSame(1, Permission::where('name', Permissions::ACT_AS_GUEST_USER)->count(), 'There should be exactly one act_as_guest permission.');
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to filter users in the `UserResource` table based on whether they are guest users. A "guest user" is defined as a user possessing the `ACT_AS_GUEST_USER` permission. This allows administrators to easily distinguish between regular and guest user accounts.

Key changes include:

- **User Type Filter:** Implemented a ternary filter in `UserResource` to allow viewing "All Users," "Guest Users," or "Regular Users."
- **Permission and Policy:**
  - The permission `ACT_AS_GUEST` was renamed to `ACT_AS_GUEST_USER` for better clarity.
  - An `actAsGuest` method was added to the `UserPolicy` to handle specific authorization checks for this capability.
  - `UserResource` now integrates with Filament Shield by implementing `HasShieldPermissions`.
- **End-to-End Testing:**
  - A new feature test (`UserResourceFilterTest.php`) was added to verify that the filter correctly displays the appropriate users.
  - The test setup was subsequently refactored to use role-based permission assignments instead of direct permissioning, aligning with best practices.
- **Localization:** Added translation keys for the new filter labels in both English and Indonesian.