### PR TITLE
feat: display a notice for stories posted on behalf of guest users

### DIFF
--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -9,5 +9,6 @@ return [
         'user_type_label' => 'User Type',
         'guest_users_label' => 'Guest Users',
         'regular_users_label' => 'Regular Users',
+        'guest_user_notice' => 'This work was posted on behalf of the author by our staff. The author will not be able to respond to comments.',
     ],
 ];

--- a/lang/id/user.php
+++ b/lang/id/user.php
@@ -9,5 +9,6 @@ return [
         'user_type_label' => 'Tipe Pengguna',
         'guest_users_label' => 'Pengguna Tamu',
         'regular_users_label' => 'Pengguna Reguler',
+        'guest_user_notice' => 'Karya ini diposting atas nama penulis oleh staf kami. Penulis tidak akan dapat menanggapi komentar.',
     ],
 ];

--- a/resources/views/livewire/story/view-story.blade.php
+++ b/resources/views/livewire/story/view-story.blade.php
@@ -30,6 +30,15 @@
                             <livewire:story-vote.downvote-action :story="$story" />
                         </div>
                     </x-filament::section>
+                    @if ($story->creator->can(\App\Constants\Permissions::ACT_AS_GUEST_USER))
+                        <x-filament::section class="">
+                            <div class="flex flex-row gap-x-2">
+                                <x-filament::icon icon="heroicon-o-information-circle"
+                                    class="w-5 h-5 mt-1 text-warning-500 dark:text-warning-400" />
+                                <p>{{ __('user.resource.guest_user_notice') }}</p>
+                            </div>
+                        </x-filament::section>
+                    @endif
                     <livewire:story-comment.create-story-comment :story="$story" />
                     <livewire:story-comment.story-comments-table :story="$story" />
                 </div>

--- a/tests/Feature/E2E/GuestAuthorNoticeTest.php
+++ b/tests/Feature/E2E/GuestAuthorNoticeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\E2E;
+
+use App\Constants\Permissions;
+use App\Constants\Roles;
+use App\Enums\Story\Status;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuestAuthorNoticeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $guestUser;
+
+    protected User $regularUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup Roles and Permissions
+        $permission = Permission::firstOrCreate(['name' => Permissions::ACT_AS_GUEST_USER, 'guard_name' => 'web']);
+        $role = Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
+        $role->givePermissionTo($permission);
+
+        // Create users
+        $this->guestUser = User::factory()->create();
+        $this->guestUser->assignRole($role);
+
+        $this->regularUser = User::factory()->create();
+
+        $this->actingAs($this->regularUser);
+    }
+
+    public function test_guest_author_notice_is_displayed_for_guest_author(): void
+    {
+        // Create a story by a guest user
+        $story = Story::factory()->create([
+            'creator_id' => $this->guestUser->id,
+            'status' => Status::Publish,
+        ]);
+
+        // Visit the story page
+        $response = $this->get(route('stories.show', $story));
+
+        // Assert that the guest author notice is present
+        $response->assertSee(__('user.resource.guest_user_notice'));
+    }
+
+    public function test_guest_author_notice_is_not_displayed_for_regular_author(): void
+    {
+        // Create a story by a regular user
+        $story = Story::factory()->create([
+            'creator_id' => $this->regularUser->id,
+            'status' => Status::Publish,
+        ]);
+
+        // Visit the story page
+        $response = $this->get(route('stories.show', $story));
+
+        // Assert that the guest author notice is absent
+        $response->assertDontSee(__('user.resource.guest_user_notice'));
+    }
+}

--- a/tests/Feature/E2E/GuestUserNoticeTest.php
+++ b/tests/Feature/E2E/GuestUserNoticeTest.php
@@ -4,11 +4,14 @@ namespace Tests\Feature\E2E;
 
 use App\Constants\Roles;
 use App\Enums\Story\Status;
+use App\Models\AgeRating;
 use App\Models\Role;
 use App\Models\Story;
 use App\Models\User;
 use Database\Seeders\GuestRoleAndPermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 
 class GuestUserNoticeTest extends TestCase
@@ -18,6 +21,8 @@ class GuestUserNoticeTest extends TestCase
     protected User $guestUser;
 
     protected User $regularUser;
+
+    protected AgeRating $ageRating;
 
     protected function setUp(): void
     {
@@ -34,22 +39,13 @@ class GuestUserNoticeTest extends TestCase
 
         $this->regularUser = User::factory()->create();
 
-        $this->actingAs($this->regularUser);
-    }
+        Config::set('age_rating.guest_limit_years', 16);
 
-    public function test_guest_user_notice_is_displayed_for_guest_user(): void
-    {
-        // Create a story by a guest user
-        $story = Story::factory()->create([
-            'creator_id' => $this->guestUser->id,
-            'status' => Status::Publish,
+        $this->ageRating = AgeRating::factory()->create([
+            'age_representation' => 7,
         ]);
 
-        // Visit the story page
-        $response = $this->get(route('stories.show', $story));
-
-        // Assert that the guest user notice is present
-        $response->assertSee(__('user.resource.guest_user_notice'));
+        $this->actingAs($this->regularUser);
     }
 
     public function test_guest_user_notice_is_not_displayed_for_regular_user(): void
@@ -58,6 +54,42 @@ class GuestUserNoticeTest extends TestCase
         $story = Story::factory()->create([
             'creator_id' => $this->regularUser->id,
             'status' => Status::Publish,
+        ]);
+
+        // Visit the story page
+        $response = $this->get(route('stories.show', $story));
+
+        // Assert that the guest user notice is absent
+        $response->assertDontSee(__('user.resource.guest_user_notice'));
+    }
+
+    public function test_guest_user_notice_is_displayed_for_unauthenticated_visitor_viewing_guest_user_story(): void
+    {
+        // Create a story by a guest user
+        /** @var Story */
+        $story = Story::factory()->create([
+            'creator_id' => $this->guestUser->id,
+            'status' => Status::Publish,
+        ]);
+        $story->ageRatings()->attach($this->ageRating);
+        $story->save();
+
+        // Act as unauthenticated user
+        Auth::logout();
+
+        // Visit the story page
+        $response = $this->get(route('stories.show', $story));
+
+        // Assert that the guest user notice is present
+        $response->assertSee(__('user.resource.guest_user_notice'));
+    }
+
+    public function test_guest_user_notice_is_not_displayed_for_guest_user_story_in_draft_status(): void
+    {
+        // Create a story by a guest user in draft status
+        $story = Story::factory()->create([
+            'creator_id' => $this->guestUser->id,
+            'status' => Status::Draft,
         ]);
 
         // Visit the story page

--- a/tests/Feature/E2E/GuestUserNoticeTest.php
+++ b/tests/Feature/E2E/GuestUserNoticeTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests\Feature\E2E;
 
-use App\Constants\Permissions;
 use App\Constants\Roles;
 use App\Enums\Story\Status;
-use App\Models\Permission;
 use App\Models\Role;
 use App\Models\Story;
 use App\Models\User;
+use Database\Seeders\GuestRoleAndPermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -24,14 +23,14 @@ class GuestUserNoticeTest extends TestCase
     {
         parent::setUp();
 
-        // Setup Roles and Permissions
-        $permission = Permission::firstOrCreate(['name' => Permissions::ACT_AS_GUEST_USER, 'guard_name' => 'web']);
-        $role = Role::firstOrCreate(['name' => Roles::GUEST, 'guard_name' => 'web']);
-        $role->givePermissionTo($permission);
+        // Seed Roles and Permissions
+        $this->seed(GuestRoleAndPermissionSeeder::class);
 
         // Create users
         $this->guestUser = User::factory()->create();
-        $this->guestUser->assignRole($role);
+        /** @var Role */
+        $guestRole = Role::where('name', Roles::GUEST)->first();
+        $this->guestUser->assignRole($guestRole);
 
         $this->regularUser = User::factory()->create();
 

--- a/tests/Feature/E2E/GuestUserNoticeTest.php
+++ b/tests/Feature/E2E/GuestUserNoticeTest.php
@@ -12,7 +12,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class GuestAuthorNoticeTest extends TestCase
+class GuestUserNoticeTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -38,7 +38,7 @@ class GuestAuthorNoticeTest extends TestCase
         $this->actingAs($this->regularUser);
     }
 
-    public function test_guest_author_notice_is_displayed_for_guest_author(): void
+    public function test_guest_user_notice_is_displayed_for_guest_user(): void
     {
         // Create a story by a guest user
         $story = Story::factory()->create([
@@ -49,11 +49,11 @@ class GuestAuthorNoticeTest extends TestCase
         // Visit the story page
         $response = $this->get(route('stories.show', $story));
 
-        // Assert that the guest author notice is present
+        // Assert that the guest user notice is present
         $response->assertSee(__('user.resource.guest_user_notice'));
     }
 
-    public function test_guest_author_notice_is_not_displayed_for_regular_author(): void
+    public function test_guest_user_notice_is_not_displayed_for_regular_user(): void
     {
         // Create a story by a regular user
         $story = Story::factory()->create([
@@ -64,7 +64,7 @@ class GuestAuthorNoticeTest extends TestCase
         // Visit the story page
         $response = $this->get(route('stories.show', $story));
 
-        // Assert that the guest author notice is absent
+        // Assert that the guest user notice is absent
         $response->assertDontSee(__('user.resource.guest_user_notice'));
     }
 }


### PR DESCRIPTION
This pull request introduces a feature to display an informational notice on stories that have been posted by a staff member on behalf of a guest user. The purpose of this notice is to inform readers that the story's original author may not be a registered user and therefore might not be able to respond to comments.

Changes include:

- A new informational notice is conditionally displayed on the story view page if the creator has `ACT_AS_GUEST_USER` permission.
- Added `guest_user_notice` translation keys for English and Indonesian.
- Introduced a suite of end-to-end tests to verify the visibility logic of the notice. The tests cover scenarios for authenticated users and unauthenticated visitors, ensuring the notice appears only for published stories by guest users and not for drafts or stories by regular users.
- The test setup has been refactored to use a dedicated seeder for roles and permissions, improving consistency and maintainability.